### PR TITLE
Adding DList, Acc & snoc benchmarks

### DIFF
--- a/Time.hs
+++ b/Time.hs
@@ -10,6 +10,7 @@ import           Control.Monad.ST
 import           Criterion.Main
 import           Criterion.Types
 import qualified Data.List as L
+import qualified Data.DList as D
 import qualified Data.Sequence as S
 import qualified Data.Vector as V
 import qualified Data.Vector.Algorithms.Merge as V
@@ -42,6 +43,7 @@ main = do
         "Consing"
         (conses
            [ Conser "Data.List" sampleList (:)
+           , Conser "Data.DList" sampleDList D.cons
            , Conser "Data.Vector" sampleVector V.cons
            , Conser "Data.Vector.Unboxed" sampleUVVector UV.cons
            , Conser "Data.Vector.Storable" sampleSVVector SV.cons
@@ -64,6 +66,7 @@ main = do
         "Append"
         (appends
            [ Append "Data.List" sampleList (++) force
+           , Append "Data.DList" sampleDList D.append id
            , Append "Data.Vector" sampleVector (V.++) id
            , Append "Data.Vector.Unboxed" sampleUVVector (UV.++) id
            , Append "Data.Vector.Storable" sampleSVVector (SV.++) id
@@ -74,6 +77,7 @@ main = do
         "Length"
         (lengths
            [ Length "Data.List" sampleList L.length
+           , Length "Data.DList" sampleDList length
            , Length "Data.Vector" sampleVector V.length
            , Length "Data.Vector.Unboxed" sampleUVVector UV.length
            , Length "Data.Vector.Storable" sampleSVVector SV.length
@@ -94,6 +98,7 @@ main = do
         "Replicate"
         (replicators
            [ Replicator "Data.List" L.replicate
+           , Replicator "Data.DList" D.replicate
            , Replicator "Data.Vector" V.replicate
            , Replicator "Data.Vector.Unboxed" UV.replicate
            , Replicator "Data.Vector.Storable" SV.replicate
@@ -104,6 +109,7 @@ main = do
         "Min"
         (mins
            [ Min "Data.List" randomSampleList L.minimum
+           , Min "Data.DList" randomSampleDList minimum
            , Min "Data.Vector" randomSampleVector V.minimum
            , Min "Data.Vector.Unboxed" randomSampleUVVector UV.minimum
            , Min "Data.Vector.Storable" randomSampleSVVector SV.minimum
@@ -115,6 +121,7 @@ main = do
         "Max"
         (maxs
            [ Max "Data.List" randomSampleList L.maximum
+           , Max "Data.DList" randomSampleDList maximum
            , Max "Data.Vector" randomSampleVector V.maximum
            , Max "Data.Vector.Unboxed" randomSampleUVVector UV.maximum
            , Max "Data.Vector.Storable" randomSampleSVVector SV.maximum
@@ -250,6 +257,9 @@ sortSVec vec =
 randomSampleList :: Int -> IO [Int]
 randomSampleList i = evaluate $ force (take i (randoms (mkStdGen 0)))
 
+randomSampleDList :: Int -> IO (D.DList Int)
+randomSampleDList i = evaluate $ force $ D.fromList (take i (randoms (mkStdGen 0)))
+
 randomSampleVector :: Int -> IO (V.Vector Int)
 randomSampleVector i = evaluate $ force $ V.fromList (take i (randoms (mkStdGen 0)))
 
@@ -272,6 +282,8 @@ randomSampleRRB i = evaluate $ force $ RRB.fromList (take i (randoms (mkStdGen 0
 sampleList :: Int -> IO [Int]
 sampleList i = evaluate $ force [1..i]
 
+sampleDList :: Int -> IO (D.DList Int)
+sampleDList i = evaluate $ force $ D.fromList [1..i]
 sampleVector :: Int -> IO (V.Vector Int)
 sampleVector i = evaluate $ force $ V.fromList [1..i]
 

--- a/Time.hs
+++ b/Time.hs
@@ -18,6 +18,8 @@ import qualified Data.Vector.Unboxed as UV
 import qualified Data.Vector.Storable as SV
 import qualified Data.Massiv.Array as M
 import qualified Data.RRBVector as RRB
+import qualified Acc
+import qualified GHC.Exts
 import           System.Directory
 import           System.Random
 
@@ -49,6 +51,7 @@ main = do
            , Conser "Data.Vector.Storable" sampleSVVector SV.cons
            , Conser "Data.Sequence" sampleSeq (S.<|)
            , Conser "Data.RRBVector" sampleRRB (RRB.<|)
+           , Conser "Data.Acc" sampleAcc Acc.cons
            ])
     , bgroup
         "Indexing"
@@ -72,6 +75,7 @@ main = do
            , Append "Data.Vector.Storable" sampleSVVector (SV.++) id
            , Append "Data.Sequence" sampleSeq (S.><) id
            , Append "Data.RRBVector" sampleRRB (RRB.><) id
+           , Append "Data.Acc" sampleAcc (<>) id
            ])
     , bgroup
         "Length"
@@ -84,6 +88,7 @@ main = do
            , Length "Data.Sequence" sampleSeq S.length
            , Length "Data.Massiv.Array" sampleMassivUArray M.elemsCount
            , Length "Data.RRBVector" sampleRRB length
+           , Length "Data.Acc" sampleAcc length
            ])
     , bgroup
         "Stable Sort"
@@ -116,6 +121,7 @@ main = do
            , Min "Data.Sequence" randomSampleSeq minimum
            , Min "Data.Massiv.Array" randomSampleMassivUArray M.minimum'
            , Min "Data.RRBVector" randomSampleRRB minimum
+           , Min "Data.Acc" randomSampleAcc minimum
            ])
     , bgroup
         "Max"
@@ -128,6 +134,7 @@ main = do
            , Max "Data.Sequence" randomSampleSeq maximum
            , Max "Data.Massiv.Array" randomSampleMassivUArray M.maximum'
            , Max "Data.RRBVector" randomSampleRRB maximum
+           , Max "Data.Acc" randomSampleAcc maximum
            ])
     , bgroup
         "Filter Element"
@@ -279,6 +286,9 @@ randomSampleMassivUArray i = evaluate $ force ma where
 randomSampleRRB :: Int -> IO (RRB.Vector Int)
 randomSampleRRB i = evaluate $ force $ RRB.fromList (take i (randoms (mkStdGen 0)))
 
+randomSampleAcc :: Int -> IO (Acc.Acc Int)
+randomSampleAcc i = evaluate $ force $ GHC.Exts.fromList (take i (randoms (mkStdGen 0)))
+
 sampleList :: Int -> IO [Int]
 sampleList i = evaluate $ force [1..i]
 
@@ -303,3 +313,6 @@ sampleMassivUArray i = evaluate $ force ma where
 
 sampleRRB :: Int -> IO (RRB.Vector Int)
 sampleRRB i = evaluate $ force $ RRB.fromList [1..i]
+
+sampleAcc :: Int -> IO (Acc.Acc Int)
+sampleAcc i = evaluate $ force $ GHC.Exts.fromList [1..i]

--- a/bench.cabal
+++ b/bench.cabal
@@ -23,6 +23,7 @@ benchmark time
                    , massiv
                    , rrb-vector
                    , dlist
+                   , acc
 
 executable report
   default-language: Haskell2010

--- a/bench.cabal
+++ b/bench.cabal
@@ -22,6 +22,7 @@ benchmark time
                    , random
                    , massiv
                    , rrb-vector
+                   , dlist
 
 executable report
   default-language: Haskell2010


### PR DESCRIPTION
Closes #21, #22.

According information is put in according commit messages.

<details><summary>Current results are:</summary>

</p>

```
Build profile: -w ghc-8.10.7 -O1
In order, the following will be built (use -v for more details):
 - bench-0 (bench:time) (file Time.hs changed)
Preprocessing benchmark 'time' for bench-0..
Building benchmark 'time' for bench-0..
[1 of 1] Compiling Main             ( Time.hs, /home/pyro/src/haskell/community/sequences/dist-newstyle/build/x86_64-linux/ghc-8.10.7/bench-0/b/time/build/time/time-tmp/Main.o )
Linking /home/pyro/src/haskell/community/sequences/dist-newstyle/build/x86_64-linux/ghc-8.10.7/bench-0/b/time/build/time/time ...
Running 1 benchmarks...
Benchmark time: RUNNING...
benchmarking Consing/Data.List:10
time                 4.340 ns   (4.300 ns .. 4.388 ns)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 4.324 ns   (4.289 ns .. 4.371 ns)
std dev              140.6 ps   (109.5 ps .. 178.9 ps)
variance introduced by outliers: 56% (severely inflated)

benchmarking Consing/Data.DList:10
time                 6.814 ns   (6.743 ns .. 6.906 ns)
                     0.999 R²   (0.999 R² .. 0.999 R²)
mean                 6.913 ns   (6.840 ns .. 7.014 ns)
std dev              288.5 ps   (197.5 ps .. 409.3 ps)
variance introduced by outliers: 67% (severely inflated)

benchmarking Consing/Data.Vector:10
time                 32.59 ns   (32.33 ns .. 32.89 ns)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 32.87 ns   (32.59 ns .. 33.46 ns)
std dev              1.321 ns   (789.6 ps .. 2.347 ns)
variance introduced by outliers: 63% (severely inflated)

benchmarking Consing/Data.Vector.Unboxed:10
time                 20.46 ns   (20.26 ns .. 20.71 ns)
                     0.999 R²   (0.999 R² .. 0.999 R²)
mean                 20.64 ns   (20.47 ns .. 20.85 ns)
std dev              620.9 ps   (515.0 ps .. 852.5 ps)
variance introduced by outliers: 49% (moderately inflated)

benchmarking Consing/Data.Vector.Storable:10
time                 20.70 ns   (20.53 ns .. 20.92 ns)
                     0.999 R²   (0.999 R² .. 0.999 R²)
mean                 20.91 ns   (20.74 ns .. 21.29 ns)
std dev              794.5 ps   (510.7 ps .. 1.364 ns)
variance introduced by outliers: 61% (severely inflated)

benchmarking Consing/Data.Sequence:10
time                 10.44 ns   (10.35 ns .. 10.56 ns)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 10.55 ns   (10.45 ns .. 10.65 ns)
std dev              341.0 ps   (273.5 ps .. 479.0 ps)
variance introduced by outliers: 54% (severely inflated)

benchmarking Consing/Data.RRBVector:10
time                 29.23 ns   (28.98 ns .. 29.51 ns)
                     0.999 R²   (0.999 R² .. 0.999 R²)
mean                 29.58 ns   (29.26 ns .. 30.01 ns)
std dev              1.300 ns   (934.3 ps .. 2.062 ns)
variance introduced by outliers: 67% (severely inflated)

benchmarking Consing/Data.Acc:10
time                 8.618 ns   (8.520 ns .. 8.716 ns)
                     0.999 R²   (0.998 R² .. 0.999 R²)
mean                 8.691 ns   (8.596 ns .. 8.802 ns)
std dev              335.4 ps   (266.8 ps .. 515.4 ps)
variance introduced by outliers: 63% (severely inflated)

benchmarking Consing/Data.List:100
time                 4.392 ns   (4.348 ns .. 4.447 ns)
                     0.999 R²   (0.999 R² .. 0.999 R²)
mean                 4.417 ns   (4.377 ns .. 4.459 ns)
std dev              141.1 ps   (118.8 ps .. 168.8 ps)
variance introduced by outliers: 55% (severely inflated)

benchmarking Consing/Data.DList:100
time                 6.878 ns   (6.765 ns .. 7.012 ns)
                     0.998 R²   (0.997 R² .. 0.999 R²)
mean                 6.893 ns   (6.816 ns .. 7.001 ns)
std dev              303.6 ps   (213.7 ps .. 497.6 ps)
variance introduced by outliers: 69% (severely inflated)

benchmarking Consing/Data.Vector:100
time                 109.5 ns   (108.6 ns .. 110.6 ns)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 110.5 ns   (109.5 ns .. 111.8 ns)
std dev              3.888 ns   (2.923 ns .. 6.195 ns)
variance introduced by outliers: 54% (severely inflated)

benchmarking Consing/Data.Vector.Unboxed:100
time                 44.52 ns   (44.13 ns .. 44.98 ns)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 45.14 ns   (44.70 ns .. 45.78 ns)
std dev              1.740 ns   (1.351 ns .. 2.364 ns)
variance introduced by outliers: 60% (severely inflated)

benchmarking Consing/Data.Vector.Storable:100
time                 49.03 ns   (48.54 ns .. 49.63 ns)
                     0.999 R²   (0.998 R² .. 0.999 R²)
mean                 49.58 ns   (49.10 ns .. 50.15 ns)
std dev              1.800 ns   (1.508 ns .. 2.259 ns)
variance introduced by outliers: 57% (severely inflated)

benchmarking Consing/Data.Sequence:100
time                 10.70 ns   (10.61 ns .. 10.83 ns)
                     0.999 R²   (0.999 R² .. 0.999 R²)
mean                 10.83 ns   (10.72 ns .. 11.05 ns)
std dev              492.9 ps   (322.8 ps .. 831.0 ps)
variance introduced by outliers: 70% (severely inflated)

benchmarking Consing/Data.RRBVector:100
time                 82.16 ns   (81.34 ns .. 83.11 ns)
                     0.999 R²   (0.999 R² .. 0.999 R²)
mean                 83.31 ns   (82.46 ns .. 84.45 ns)
std dev              3.266 ns   (2.588 ns .. 4.610 ns)
variance introduced by outliers: 60% (severely inflated)

benchmarking Consing/Data.Acc:100
time                 8.540 ns   (8.467 ns .. 8.620 ns)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 8.577 ns   (8.505 ns .. 8.684 ns)
std dev              287.8 ps   (212.4 ps .. 398.3 ps)
variance introduced by outliers: 56% (severely inflated)

benchmarking Consing/Data.List:1000
time                 4.379 ns   (4.337 ns .. 4.430 ns)
                     0.999 R²   (0.999 R² .. 0.999 R²)
mean                 4.443 ns   (4.396 ns .. 4.503 ns)
std dev              180.0 ps   (141.7 ps .. 263.3 ps)
variance introduced by outliers: 66% (severely inflated)

benchmarking Consing/Data.DList:1000
time                 6.823 ns   (6.726 ns .. 6.970 ns)
                     0.997 R²   (0.995 R² .. 0.999 R²)
mean                 6.915 ns   (6.817 ns .. 7.033 ns)
std dev              367.8 ps   (273.8 ps .. 511.5 ps)
variance introduced by outliers: 77% (severely inflated)

benchmarking Consing/Data.Vector:1000
time                 855.2 ns   (847.0 ns .. 866.3 ns)
                     0.999 R²   (0.998 R² .. 0.999 R²)
mean                 867.6 ns   (858.9 ns .. 878.5 ns)
std dev              32.46 ns   (26.38 ns .. 47.31 ns)
variance introduced by outliers: 53% (severely inflated)

benchmarking Consing/Data.Vector.Unboxed:1000
time                 272.1 ns   (269.0 ns .. 277.2 ns)
                     0.998 R²   (0.997 R² .. 0.999 R²)
mean                 274.8 ns   (271.7 ns .. 278.8 ns)
std dev              11.72 ns   (9.508 ns .. 14.35 ns)
variance introduced by outliers: 62% (severely inflated)

benchmarking Consing/Data.Vector.Storable:1000
time                 277.2 ns   (274.6 ns .. 280.1 ns)
                     0.999 R²   (0.999 R² .. 0.999 R²)
mean                 280.1 ns   (277.4 ns .. 284.1 ns)
std dev              11.15 ns   (7.699 ns .. 17.84 ns)
variance introduced by outliers: 58% (severely inflated)

benchmarking Consing/Data.Sequence:1000
time                 10.83 ns   (10.71 ns .. 10.98 ns)
                     0.999 R²   (0.998 R² .. 0.999 R²)
mean                 10.90 ns   (10.79 ns .. 11.04 ns)
std dev              414.2 ps   (341.2 ps .. 506.2 ps)
variance introduced by outliers: 62% (severely inflated)

benchmarking Consing/Data.RRBVector:1000
time                 80.80 ns   (79.95 ns .. 81.99 ns)
                     0.999 R²   (0.998 R² .. 0.999 R²)
mean                 81.87 ns   (80.99 ns .. 83.19 ns)
std dev              3.392 ns   (2.507 ns .. 5.382 ns)
variance introduced by outliers: 62% (severely inflated)

benchmarking Consing/Data.Acc:1000
time                 8.665 ns   (8.575 ns .. 8.770 ns)
                     0.999 R²   (0.998 R² .. 0.999 R²)
mean                 8.809 ns   (8.720 ns .. 8.927 ns)
std dev              356.3 ps   (264.1 ps .. 488.5 ps)
variance introduced by outliers: 65% (severely inflated)

benchmarking Consing/Data.List:10000
time                 4.413 ns   (4.367 ns .. 4.470 ns)
                     0.999 R²   (0.998 R² .. 0.999 R²)
mean                 4.461 ns   (4.411 ns .. 4.522 ns)
std dev              184.6 ps   (149.5 ps .. 252.9 ps)
variance introduced by outliers: 67% (severely inflated)

benchmarking Consing/Data.DList:10000
time                 6.888 ns   (6.820 ns .. 6.959 ns)
                     0.999 R²   (0.998 R² .. 0.999 R²)
mean                 6.925 ns   (6.861 ns .. 7.019 ns)
std dev              256.3 ps   (204.9 ps .. 342.9 ps)
variance introduced by outliers: 61% (severely inflated)

benchmarking Consing/Data.Vector:10000
time                 8.722 μs   (8.621 μs .. 8.853 μs)
                     0.998 R²   (0.997 R² .. 0.999 R²)
mean                 8.809 μs   (8.701 μs .. 8.947 μs)
std dev              433.6 ns   (309.2 ns .. 669.7 ns)
variance introduced by outliers: 60% (severely inflated)

benchmarking Consing/Data.Vector.Unboxed:10000
time                 2.966 μs   (2.929 μs .. 3.011 μs)
                     0.999 R²   (0.998 R² .. 0.999 R²)
mean                 2.985 μs   (2.956 μs .. 3.019 μs)
std dev              106.3 ns   (87.43 ns .. 138.1 ns)
variance introduced by outliers: 47% (moderately inflated)

benchmarking Consing/Data.Vector.Storable:10000
time                 2.959 μs   (2.933 μs .. 2.991 μs)
                     0.999 R²   (0.999 R² .. 0.999 R²)
mean                 3.010 μs   (2.977 μs .. 3.046 μs)
std dev              114.9 ns   (86.30 ns .. 172.5 ns)
variance introduced by outliers: 50% (severely inflated)

benchmarking Consing/Data.Sequence:10000
time                 10.97 ns   (10.74 ns .. 11.22 ns)
                     0.997 R²   (0.996 R² .. 0.999 R²)
mean                 10.93 ns   (10.81 ns .. 11.13 ns)
std dev              515.5 ps   (403.8 ps .. 699.2 ps)
variance introduced by outliers: 71% (severely inflated)

benchmarking Consing/Data.RRBVector:10000
time                 88.93 ns   (88.08 ns .. 89.95 ns)
                     0.999 R²   (0.999 R² .. 0.999 R²)
mean                 89.92 ns   (89.11 ns .. 90.90 ns)
std dev              3.064 ns   (2.373 ns .. 4.206 ns)
variance introduced by outliers: 53% (severely inflated)

benchmarking Consing/Data.Acc:10000
time                 8.640 ns   (8.525 ns .. 8.760 ns)
                     0.999 R²   (0.998 R² .. 0.999 R²)
mean                 8.681 ns   (8.581 ns .. 8.811 ns)
std dev              379.8 ps   (289.9 ps .. 517.8 ps)
variance introduced by outliers: 69% (severely inflated)

benchmarking Snocing/Data.DList:10
time                 6.901 ns   (6.838 ns .. 6.978 ns)
                     0.999 R²   (0.998 R² .. 0.999 R²)
mean                 6.950 ns   (6.869 ns .. 7.048 ns)
std dev              315.6 ps   (240.9 ps .. 449.3 ps)
variance introduced by outliers: 71% (severely inflated)

benchmarking Snocing/Data.Vector:10
time                 32.35 ns   (31.97 ns .. 32.83 ns)
                     0.999 R²   (0.998 R² .. 0.999 R²)
mean                 32.87 ns   (32.49 ns .. 33.31 ns)
std dev              1.459 ns   (1.121 ns .. 2.119 ns)
variance introduced by outliers: 67% (severely inflated)

benchmarking Snocing/Data.Vector.Unboxed:10
time                 19.99 ns   (19.77 ns .. 20.24 ns)
                     0.999 R²   (0.998 R² .. 0.999 R²)
mean                 20.13 ns   (19.92 ns .. 20.38 ns)
std dev              761.4 ps   (580.1 ps .. 1.009 ns)
variance introduced by outliers: 61% (severely inflated)

benchmarking Snocing/Data.Vector.Storable:10
time                 20.67 ns   (20.40 ns .. 21.06 ns)
                     0.998 R²   (0.995 R² .. 0.999 R²)
mean                 20.94 ns   (20.70 ns .. 21.42 ns)
std dev              1.098 ns   (680.2 ps .. 1.896 ns)
variance introduced by outliers: 75% (severely inflated)

benchmarking Snocing/Data.Sequence:10
time                 10.46 ns   (10.35 ns .. 10.59 ns)
                     0.999 R²   (0.998 R² .. 0.999 R²)
mean                 10.60 ns   (10.47 ns .. 10.76 ns)
std dev              475.3 ps   (392.1 ps .. 574.3 ps)
variance introduced by outliers: 70% (severely inflated)

benchmarking Snocing/Data.RRBVector:10
time                 29.71 ns   (29.41 ns .. 30.07 ns)
                     0.999 R²   (0.999 R² .. 0.999 R²)
mean                 29.89 ns   (29.65 ns .. 30.20 ns)
std dev              915.2 ps   (788.7 ps .. 1.128 ns)
variance introduced by outliers: 49% (moderately inflated)

benchmarking Snocing/Data.Acc:10
time                 8.568 ns   (8.484 ns .. 8.670 ns)
                     0.999 R²   (0.998 R² .. 0.999 R²)
mean                 8.647 ns   (8.560 ns .. 8.750 ns)
std dev              328.1 ps   (250.4 ps .. 509.1 ps)
variance introduced by outliers: 62% (severely inflated)

benchmarking Snocing/Data.DList:100
time                 6.874 ns   (6.794 ns .. 6.959 ns)
                     0.999 R²   (0.998 R² .. 0.999 R²)
mean                 6.901 ns   (6.832 ns .. 6.992 ns)
std dev              267.0 ps   (205.9 ps .. 364.6 ps)
variance introduced by outliers: 63% (severely inflated)

benchmarking Snocing/Data.Vector:100
time                 118.3 ns   (115.7 ns .. 120.3 ns)
                     0.997 R²   (0.996 R² .. 0.998 R²)
mean                 114.8 ns   (112.8 ns .. 116.9 ns)
std dev              6.664 ns   (5.609 ns .. 8.067 ns)
variance introduced by outliers: 76% (severely inflated)

benchmarking Snocing/Data.Vector.Unboxed:100
time                 50.00 ns   (49.19 ns .. 50.70 ns)
                     0.997 R²   (0.996 R² .. 0.999 R²)
mean                 48.86 ns   (48.09 ns .. 49.71 ns)
std dev              2.863 ns   (2.415 ns .. 3.581 ns)
variance introduced by outliers: 78% (severely inflated)

benchmarking Snocing/Data.Vector.Storable:100
time                 52.89 ns   (52.02 ns .. 53.52 ns)
                     0.998 R²   (0.997 R² .. 0.999 R²)
mean                 52.54 ns   (51.81 ns .. 53.33 ns)
std dev              2.621 ns   (2.078 ns .. 3.637 ns)
variance introduced by outliers: 72% (severely inflated)

benchmarking Snocing/Data.Sequence:100
time                 9.083 ns   (8.935 ns .. 9.246 ns)
                     0.998 R²   (0.997 R² .. 0.999 R²)
mean                 9.268 ns   (9.122 ns .. 9.433 ns)
std dev              527.2 ps   (453.5 ps .. 673.9 ps)
variance introduced by outliers: 79% (severely inflated)

benchmarking Snocing/Data.RRBVector:100
time                 44.80 ns   (44.28 ns .. 45.43 ns)
                     0.998 R²   (0.996 R² .. 0.999 R²)
mean                 44.91 ns   (44.40 ns .. 45.78 ns)
std dev              2.255 ns   (1.468 ns .. 3.352 ns)
variance introduced by outliers: 72% (severely inflated)

benchmarking Snocing/Data.Acc:100
time                 8.493 ns   (8.440 ns .. 8.557 ns)
                     0.999 R²   (0.998 R² .. 1.000 R²)
mean                 8.645 ns   (8.564 ns .. 8.878 ns)
std dev              417.0 ps   (209.5 ps .. 819.0 ps)
variance introduced by outliers: 73% (severely inflated)

benchmarking Snocing/Data.DList:1000
time                 6.769 ns   (6.704 ns .. 6.852 ns)
                     0.999 R²   (0.998 R² .. 1.000 R²)
mean                 6.766 ns   (6.711 ns .. 6.851 ns)
std dev              234.5 ps   (179.7 ps .. 321.5 ps)
variance introduced by outliers: 58% (severely inflated)

benchmarking Snocing/Data.Vector:1000
time                 812.6 ns   (803.9 ns .. 822.9 ns)
                     0.999 R²   (0.998 R² .. 0.999 R²)
mean                 814.8 ns   (806.9 ns .. 827.5 ns)
std dev              32.98 ns   (22.60 ns .. 52.67 ns)
variance introduced by outliers: 57% (severely inflated)

benchmarking Snocing/Data.Vector.Unboxed:1000
time                 265.8 ns   (263.9 ns .. 267.7 ns)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 265.0 ns   (263.1 ns .. 267.4 ns)
std dev              7.264 ns   (6.225 ns .. 8.794 ns)
variance introduced by outliers: 40% (moderately inflated)

benchmarking Snocing/Data.Vector.Storable:1000
time                 265.1 ns   (262.7 ns .. 267.9 ns)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 265.9 ns   (263.4 ns .. 269.8 ns)
std dev              10.01 ns   (7.055 ns .. 15.20 ns)
variance introduced by outliers: 56% (severely inflated)

benchmarking Snocing/Data.Sequence:1000
time                 8.689 ns   (8.611 ns .. 8.765 ns)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 8.714 ns   (8.639 ns .. 8.825 ns)
std dev              303.4 ps   (220.7 ps .. 410.8 ps)
variance introduced by outliers: 58% (severely inflated)

benchmarking Snocing/Data.RRBVector:1000
time                 65.17 ns   (64.58 ns .. 65.79 ns)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 65.19 ns   (64.56 ns .. 65.99 ns)
std dev              2.308 ns   (1.780 ns .. 3.077 ns)
variance introduced by outliers: 55% (severely inflated)

benchmarking Snocing/Data.Acc:1000
time                 8.837 ns   (8.638 ns .. 9.080 ns)
                     0.993 R²   (0.989 R² .. 0.997 R²)
mean                 8.919 ns   (8.710 ns .. 9.188 ns)
std dev              787.4 ps   (621.2 ps .. 957.5 ps)
variance introduced by outliers: 90% (severely inflated)

benchmarking Snocing/Data.DList:10000
time                 6.824 ns   (6.744 ns .. 6.903 ns)
                     0.999 R²   (0.998 R² .. 1.000 R²)
mean                 6.783 ns   (6.725 ns .. 6.849 ns)
std dev              212.5 ps   (174.1 ps .. 281.4 ps)
variance introduced by outliers: 53% (severely inflated)

benchmarking Snocing/Data.Vector:10000
time                 8.620 μs   (8.558 μs .. 8.691 μs)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 8.675 μs   (8.593 μs .. 8.859 μs)
std dev              354.1 ns   (217.3 ns .. 641.8 ns)
variance introduced by outliers: 51% (severely inflated)

benchmarking Snocing/Data.Vector.Unboxed:10000
time                 2.748 μs   (2.734 μs .. 2.763 μs)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 2.748 μs   (2.730 μs .. 2.772 μs)
std dev              72.98 ns   (56.30 ns .. 96.57 ns)
variance introduced by outliers: 33% (moderately inflated)

benchmarking Snocing/Data.Vector.Storable:10000
time                 2.683 μs   (2.640 μs .. 2.734 μs)
                     0.998 R²   (0.997 R² .. 0.999 R²)
mean                 2.676 μs   (2.650 μs .. 2.708 μs)
std dev              98.96 ns   (73.76 ns .. 132.5 ns)
variance introduced by outliers: 49% (moderately inflated)

benchmarking Snocing/Data.Sequence:10000
time                 8.863 ns   (8.782 ns .. 8.936 ns)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 8.814 ns   (8.743 ns .. 8.911 ns)
std dev              288.3 ps   (208.7 ps .. 455.0 ps)
variance introduced by outliers: 55% (severely inflated)

benchmarking Snocing/Data.RRBVector:10000
time                 62.34 ns   (61.96 ns .. 62.68 ns)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 62.27 ns   (61.72 ns .. 63.01 ns)
std dev              2.072 ns   (1.582 ns .. 3.018 ns)
variance introduced by outliers: 52% (severely inflated)

benchmarking Snocing/Data.Acc:10000
time                 8.743 ns   (8.642 ns .. 8.858 ns)
                     0.999 R²   (0.998 R² .. 0.999 R²)
mean                 8.665 ns   (8.594 ns .. 8.763 ns)
std dev              292.5 ps   (234.8 ps .. 358.9 ps)
variance introduced by outliers: 56% (severely inflated)

benchmarking Indexing/Data.List:10
time                 30.44 ns   (30.14 ns .. 30.75 ns)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 30.44 ns   (30.22 ns .. 30.78 ns)
std dev              931.3 ps   (721.6 ps .. 1.256 ns)
variance introduced by outliers: 49% (moderately inflated)

benchmarking Indexing/Data.Vector:10
time                 8.572 ns   (8.505 ns .. 8.643 ns)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 8.589 ns   (8.514 ns .. 8.694 ns)
std dev              293.9 ps   (215.3 ps .. 393.6 ps)
variance introduced by outliers: 57% (severely inflated)

benchmarking Indexing/Data.Vector.Unboxed:10
time                 8.596 ns   (8.541 ns .. 8.665 ns)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 8.626 ns   (8.560 ns .. 8.702 ns)
std dev              238.6 ps   (185.5 ps .. 340.6 ps)
variance introduced by outliers: 46% (moderately inflated)

benchmarking Indexing/Data.Vector.Storable:10
time                 8.922 ns   (8.793 ns .. 9.081 ns)
                     0.999 R²   (0.998 R² .. 1.000 R²)
mean                 8.904 ns   (8.828 ns .. 9.003 ns)
std dev              299.6 ps   (228.2 ps .. 415.1 ps)
variance introduced by outliers: 56% (severely inflated)

benchmarking Indexing/Data.Sequence:10
time                 29.66 ns   (29.44 ns .. 29.93 ns)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 29.71 ns   (29.51 ns .. 29.95 ns)
std dev              765.1 ps   (575.6 ps .. 1.077 ns)
variance introduced by outliers: 41% (moderately inflated)

benchmarking Indexing/Data.Massiv.Array:10
time                 13.08 ns   (12.92 ns .. 13.26 ns)
                     0.999 R²   (0.998 R² .. 1.000 R²)
mean                 13.01 ns   (12.89 ns .. 13.16 ns)
std dev              438.9 ps   (350.0 ps .. 580.3 ps)
variance introduced by outliers: 56% (severely inflated)

benchmarking Indexing/Data.RRBVector:10
time                 19.07 ns   (18.93 ns .. 19.20 ns)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 19.11 ns   (18.92 ns .. 19.47 ns)
std dev              795.7 ps   (450.8 ps .. 1.459 ns)
variance introduced by outliers: 65% (severely inflated)

benchmarking Indexing/Data.List:100
time                 229.3 ns   (227.4 ns .. 231.4 ns)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 229.6 ns   (227.8 ns .. 233.1 ns)
std dev              8.594 ns   (4.999 ns .. 15.47 ns)
variance introduced by outliers: 55% (severely inflated)

benchmarking Indexing/Data.Vector:100
time                 8.580 ns   (8.526 ns .. 8.636 ns)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 8.572 ns   (8.518 ns .. 8.650 ns)
std dev              205.9 ps   (159.3 ps .. 299.4 ps)
variance introduced by outliers: 39% (moderately inflated)

benchmarking Indexing/Data.Vector.Unboxed:100
time                 8.570 ns   (8.513 ns .. 8.643 ns)
                     0.999 R²   (0.998 R² .. 1.000 R²)
mean                 8.627 ns   (8.547 ns .. 8.778 ns)
std dev              350.7 ps   (224.7 ps .. 560.9 ps)
variance introduced by outliers: 66% (severely inflated)

benchmarking Indexing/Data.Vector.Storable:100
time                 8.856 ns   (8.781 ns .. 8.930 ns)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 8.881 ns   (8.807 ns .. 8.987 ns)
std dev              286.8 ps   (203.8 ps .. 410.0 ps)
variance introduced by outliers: 54% (severely inflated)

benchmarking Indexing/Data.Sequence:100
time                 57.39 ns   (57.00 ns .. 57.74 ns)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 57.31 ns   (56.96 ns .. 57.72 ns)
std dev              1.296 ns   (1.038 ns .. 1.844 ns)
variance introduced by outliers: 33% (moderately inflated)

benchmarking Indexing/Data.Massiv.Array:100
time                 12.96 ns   (12.86 ns .. 13.07 ns)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 12.97 ns   (12.87 ns .. 13.07 ns)
std dev              318.1 ps   (265.8 ps .. 384.3 ps)
variance introduced by outliers: 40% (moderately inflated)

benchmarking Indexing/Data.RRBVector:100
time                 19.13 ns   (18.90 ns .. 19.46 ns)
                     0.999 R²   (0.998 R² .. 1.000 R²)
mean                 19.04 ns   (18.91 ns .. 19.24 ns)
std dev              539.2 ps   (425.0 ps .. 736.7 ps)
variance introduced by outliers: 46% (moderately inflated)

benchmarking Indexing/Data.List:1000
time                 2.130 μs   (2.117 μs .. 2.144 μs)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 2.136 μs   (2.122 μs .. 2.154 μs)
std dev              53.58 ns   (43.59 ns .. 72.47 ns)
variance introduced by outliers: 31% (moderately inflated)

benchmarking Indexing/Data.Vector:1000
time                 8.568 ns   (8.499 ns .. 8.641 ns)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 8.591 ns   (8.532 ns .. 8.646 ns)
std dev              189.7 ps   (154.1 ps .. 243.7 ps)
variance introduced by outliers: 35% (moderately inflated)

benchmarking Indexing/Data.Vector.Unboxed:1000
time                 8.616 ns   (8.545 ns .. 8.692 ns)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 8.604 ns   (8.534 ns .. 8.706 ns)
std dev              272.3 ps   (196.9 ps .. 461.7 ps)
variance introduced by outliers: 53% (severely inflated)

benchmarking Indexing/Data.Vector.Storable:1000
time                 8.865 ns   (8.797 ns .. 8.931 ns)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 8.855 ns   (8.790 ns .. 8.926 ns)
std dev              228.0 ps   (192.9 ps .. 268.7 ps)
variance introduced by outliers: 43% (moderately inflated)

benchmarking Indexing/Data.Sequence:1000
time                 88.18 ns   (87.39 ns .. 89.10 ns)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 88.19 ns   (87.51 ns .. 89.07 ns)
std dev              2.566 ns   (1.957 ns .. 3.564 ns)
variance introduced by outliers: 45% (moderately inflated)

benchmarking Indexing/Data.Massiv.Array:1000
time                 13.08 ns   (12.98 ns .. 13.19 ns)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 13.11 ns   (13.01 ns .. 13.27 ns)
std dev              424.8 ps   (299.6 ps .. 707.5 ps)
variance introduced by outliers: 54% (severely inflated)

benchmarking Indexing/Data.RRBVector:1000
time                 19.98 ns   (19.44 ns .. 20.48 ns)
                     0.996 R²   (0.994 R² .. 0.998 R²)
mean                 19.39 ns   (19.13 ns .. 19.80 ns)
std dev              1.025 ns   (780.2 ps .. 1.428 ns)
variance introduced by outliers: 75% (severely inflated)

benchmarking Indexing/Data.List:10000
time                 26.09 μs   (25.47 μs .. 26.52 μs)
                     0.997 R²   (0.996 R² .. 0.998 R²)
mean                 25.22 μs   (24.86 μs .. 25.62 μs)
std dev              1.267 μs   (1.062 μs .. 1.506 μs)
variance introduced by outliers: 58% (severely inflated)

benchmarking Indexing/Data.Vector:10000
time                 8.698 ns   (8.615 ns .. 8.808 ns)
                     0.999 R²   (0.998 R² .. 0.999 R²)
mean                 8.710 ns   (8.607 ns .. 8.912 ns)
std dev              465.1 ps   (322.2 ps .. 766.6 ps)
variance introduced by outliers: 77% (severely inflated)

benchmarking Indexing/Data.Vector.Unboxed:10000
time                 8.587 ns   (8.525 ns .. 8.660 ns)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 8.590 ns   (8.533 ns .. 8.658 ns)
std dev              213.0 ps   (172.2 ps .. 261.2 ps)
variance introduced by outliers: 41% (moderately inflated)

benchmarking Indexing/Data.Vector.Storable:10000
time                 8.901 ns   (8.830 ns .. 8.978 ns)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 8.918 ns   (8.843 ns .. 9.007 ns)
std dev              283.3 ps   (215.2 ps .. 416.5 ps)
variance introduced by outliers: 53% (severely inflated)

benchmarking Indexing/Data.Sequence:10000
time                 33.10 ns   (32.26 ns .. 33.82 ns)
                     0.998 R²   (0.997 R² .. 0.999 R²)
mean                 32.41 ns   (32.12 ns .. 32.83 ns)
std dev              1.187 ns   (953.0 ps .. 1.530 ns)
variance introduced by outliers: 58% (severely inflated)

benchmarking Indexing/Data.Massiv.Array:10000
time                 13.35 ns   (13.20 ns .. 13.52 ns)
                     0.999 R²   (0.998 R² .. 0.999 R²)
mean                 13.66 ns   (13.51 ns .. 13.81 ns)
std dev              505.1 ps   (412.1 ps .. 638.1 ps)
variance introduced by outliers: 60% (severely inflated)

benchmarking Indexing/Data.RRBVector:10000
time                 19.50 ns   (19.17 ns .. 19.88 ns)
                     0.998 R²   (0.996 R² .. 0.999 R²)
mean                 19.49 ns   (19.22 ns .. 20.25 ns)
std dev              1.295 ns   (629.2 ps .. 2.572 ns)
variance introduced by outliers: 83% (severely inflated)

benchmarking Append/Data.List:10
time                 91.80 ns   (90.57 ns .. 93.48 ns)
                     0.997 R²   (0.995 R² .. 0.999 R²)
mean                 92.50 ns   (91.07 ns .. 94.47 ns)
std dev              5.420 ns   (4.091 ns .. 7.046 ns)
variance introduced by outliers: 77% (severely inflated)

benchmarking Append/Data.DList:10
time                 13.26 ns   (13.08 ns .. 13.48 ns)
                     0.998 R²   (0.997 R² .. 0.999 R²)
mean                 13.24 ns   (13.06 ns .. 13.42 ns)
std dev              630.0 ps   (517.0 ps .. 904.4 ps)
variance introduced by outliers: 72% (severely inflated)

benchmarking Append/Data.Vector:10
time                 53.35 ns   (52.67 ns .. 54.20 ns)
                     0.998 R²   (0.997 R² .. 0.999 R²)
mean                 53.71 ns   (53.10 ns .. 54.55 ns)
std dev              2.367 ns   (1.887 ns .. 3.309 ns)
variance introduced by outliers: 66% (severely inflated)

benchmarking Append/Data.Vector.Unboxed:10
time                 29.26 ns   (29.01 ns .. 29.53 ns)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 29.34 ns   (29.09 ns .. 29.61 ns)
std dev              924.3 ps   (754.9 ps .. 1.136 ns)
variance introduced by outliers: 51% (severely inflated)

benchmarking Append/Data.Vector.Storable:10
time                 31.61 ns   (31.39 ns .. 31.86 ns)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 31.69 ns   (31.42 ns .. 31.99 ns)
std dev              978.3 ps   (752.2 ps .. 1.269 ns)
variance introduced by outliers: 50% (moderately inflated)

benchmarking Append/Data.Sequence:10
time                 52.72 ns   (52.32 ns .. 53.20 ns)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 52.93 ns   (52.47 ns .. 53.53 ns)
std dev              1.707 ns   (1.239 ns .. 2.277 ns)
variance introduced by outliers: 51% (severely inflated)

benchmarking Append/Data.RRBVector:10
time                 59.59 ns   (58.94 ns .. 60.33 ns)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 59.78 ns   (59.20 ns .. 60.62 ns)
std dev              2.325 ns   (1.750 ns .. 3.625 ns)
variance introduced by outliers: 60% (severely inflated)

benchmarking Append/Data.Acc:10
time                 13.56 ns   (13.46 ns .. 13.66 ns)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 13.42 ns   (13.28 ns .. 13.54 ns)
std dev              434.7 ps   (328.8 ps .. 583.8 ps)
variance introduced by outliers: 54% (severely inflated)

benchmarking Append/Data.List:100
time                 989.6 ns   (982.3 ns .. 996.5 ns)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 982.2 ns   (975.5 ns .. 991.0 ns)
std dev              26.47 ns   (20.47 ns .. 39.68 ns)
variance introduced by outliers: 36% (moderately inflated)

benchmarking Append/Data.DList:100
time                 13.30 ns   (13.07 ns .. 13.53 ns)
                     0.998 R²   (0.997 R² .. 0.999 R²)
mean                 13.43 ns   (13.29 ns .. 13.64 ns)
std dev              556.9 ps   (416.1 ps .. 813.0 ps)
variance introduced by outliers: 66% (severely inflated)

benchmarking Append/Data.Vector:100
time                 197.4 ns   (196.4 ns .. 198.6 ns)
                     0.999 R²   (0.998 R² .. 1.000 R²)
mean                 197.9 ns   (196.2 ns .. 202.2 ns)
std dev              8.897 ns   (4.367 ns .. 15.50 ns)
variance introduced by outliers: 65% (severely inflated)

benchmarking Append/Data.Vector.Unboxed:100
time                 78.81 ns   (78.13 ns .. 79.60 ns)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 78.89 ns   (78.27 ns .. 79.89 ns)
std dev              2.524 ns   (1.722 ns .. 4.103 ns)
variance introduced by outliers: 50% (moderately inflated)

benchmarking Append/Data.Vector.Storable:100
time                 91.87 ns   (91.25 ns .. 92.45 ns)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 91.40 ns   (90.76 ns .. 91.98 ns)
std dev              2.107 ns   (1.726 ns .. 2.629 ns)
variance introduced by outliers: 34% (moderately inflated)

benchmarking Append/Data.Sequence:100
time                 117.3 ns   (116.1 ns .. 118.6 ns)
                     0.999 R²   (0.998 R² .. 0.999 R²)
mean                 118.7 ns   (117.5 ns .. 120.7 ns)
std dev              5.305 ns   (3.581 ns .. 8.644 ns)
variance introduced by outliers: 65% (severely inflated)

benchmarking Append/Data.RRBVector:100
time                 829.2 ns   (821.5 ns .. 838.2 ns)
                     0.999 R²   (0.999 R² .. 0.999 R²)
mean                 835.4 ns   (827.0 ns .. 843.8 ns)
std dev              28.29 ns   (24.06 ns .. 33.64 ns)
variance introduced by outliers: 48% (moderately inflated)

benchmarking Append/Data.Acc:100
time                 12.86 ns   (12.73 ns .. 13.03 ns)
                     0.999 R²   (0.998 R² .. 0.999 R²)
mean                 13.09 ns   (12.94 ns .. 13.32 ns)
std dev              623.6 ps   (420.7 ps .. 887.4 ps)
variance introduced by outliers: 72% (severely inflated)

benchmarking Append/Data.List:1000
time                 10.35 μs   (10.04 μs .. 10.65 μs)
                     0.996 R²   (0.994 R² .. 0.998 R²)
mean                 9.988 μs   (9.847 μs .. 10.17 μs)
std dev              543.7 ns   (442.0 ns .. 689.4 ns)
variance introduced by outliers: 64% (severely inflated)

benchmarking Append/Data.DList:1000
time                 14.96 ns   (14.29 ns .. 15.65 ns)
                     0.990 R²   (0.984 R² .. 0.996 R²)
mean                 14.34 ns   (14.00 ns .. 14.75 ns)
std dev              1.270 ns   (998.7 ps .. 1.665 ns)
variance introduced by outliers: 90% (severely inflated)

benchmarking Append/Data.Vector:1000
time                 1.760 μs   (1.732 μs .. 1.795 μs)
                     0.995 R²   (0.992 R² .. 0.997 R²)
mean                 1.856 μs   (1.812 μs .. 1.932 μs)
std dev              188.3 ns   (119.3 ns .. 320.0 ns)
variance introduced by outliers: 89% (severely inflated)

benchmarking Append/Data.Vector.Unboxed:1000
time                 519.0 ns   (511.5 ns .. 532.1 ns)
                     0.996 R²   (0.994 R² .. 0.998 R²)
mean                 545.5 ns   (535.1 ns .. 559.4 ns)
std dev              39.71 ns   (33.13 ns .. 49.83 ns)
variance introduced by outliers: 82% (severely inflated)

benchmarking Append/Data.Vector.Storable:1000
time                 512.2 ns   (508.3 ns .. 515.7 ns)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 512.1 ns   (507.3 ns .. 518.9 ns)
std dev              18.71 ns   (14.19 ns .. 28.25 ns)
variance introduced by outliers: 53% (severely inflated)

benchmarking Append/Data.Sequence:1000
time                 182.2 ns   (180.5 ns .. 184.6 ns)
                     0.999 R²   (0.998 R² .. 0.999 R²)
mean                 182.7 ns   (180.5 ns .. 186.0 ns)
std dev              9.238 ns   (6.123 ns .. 14.92 ns)
variance introduced by outliers: 70% (severely inflated)

benchmarking Append/Data.RRBVector:1000
time                 3.541 μs   (3.453 μs .. 3.639 μs)
                     0.996 R²   (0.994 R² .. 0.997 R²)
mean                 3.586 μs   (3.528 μs .. 3.658 μs)
std dev              206.4 ns   (173.7 ns .. 261.2 ns)
variance introduced by outliers: 70% (severely inflated)

benchmarking Append/Data.Acc:1000
time                 15.66 ns   (14.82 ns .. 16.70 ns)
                     0.976 R²   (0.967 R² .. 0.986 R²)
mean                 15.61 ns   (14.93 ns .. 16.63 ns)
std dev              2.638 ns   (2.123 ns .. 3.308 ns)
variance introduced by outliers: 97% (severely inflated)

benchmarking Append/Data.List:10000
time                 174.7 μs   (155.6 μs .. 191.1 μs)
                     0.946 R²   (0.927 R² .. 0.982 R²)
mean                 169.0 μs   (160.6 μs .. 178.3 μs)
std dev              31.14 μs   (23.73 μs .. 40.03 μs)
variance introduced by outliers: 94% (severely inflated)

benchmarking Append/Data.DList:10000
time                 13.70 ns   (13.22 ns .. 14.26 ns)
                     0.991 R²   (0.987 R² .. 0.996 R²)
mean                 14.08 ns   (13.78 ns .. 14.52 ns)
std dev              1.294 ns   (933.8 ps .. 2.102 ns)
variance introduced by outliers: 90% (severely inflated)

benchmarking Append/Data.Vector:10000
time                 18.18 μs   (17.93 μs .. 18.43 μs)
                     0.999 R²   (0.998 R² .. 0.999 R²)
mean                 18.27 μs   (18.05 μs .. 18.54 μs)
std dev              804.8 ns   (618.8 ns .. 1.063 μs)
variance introduced by outliers: 52% (severely inflated)

benchmarking Append/Data.Vector.Unboxed:10000
time                 5.390 μs   (5.329 μs .. 5.456 μs)
                     0.999 R²   (0.998 R² .. 0.999 R²)
mean                 5.410 μs   (5.352 μs .. 5.492 μs)
std dev              232.9 ns   (177.6 ns .. 309.9 ns)
variance introduced by outliers: 55% (severely inflated)

benchmarking Append/Data.Vector.Storable:10000
time                 5.399 μs   (5.353 μs .. 5.456 μs)
                     0.999 R²   (0.999 R² .. 0.999 R²)
mean                 5.389 μs   (5.342 μs .. 5.439 μs)
std dev              162.0 ns   (134.2 ns .. 196.4 ns)
variance introduced by outliers: 37% (moderately inflated)

benchmarking Append/Data.Sequence:10000
time                 285.2 ns   (278.9 ns .. 291.8 ns)
                     0.997 R²   (0.996 R² .. 0.998 R²)
mean                 283.7 ns   (279.0 ns .. 288.8 ns)
std dev              15.73 ns   (13.16 ns .. 20.12 ns)
variance introduced by outliers: 73% (severely inflated)

benchmarking Append/Data.RRBVector:10000
time                 6.175 μs   (5.997 μs .. 6.385 μs)
                     0.993 R²   (0.990 R² .. 0.997 R²)
mean                 6.206 μs   (6.090 μs .. 6.332 μs)
std dev              420.2 ns   (340.3 ns .. 541.9 ns)
variance introduced by outliers: 75% (severely inflated)

benchmarking Append/Data.Acc:10000
time                 14.28 ns   (14.01 ns .. 14.49 ns)
                     0.998 R²   (0.997 R² .. 0.999 R²)
mean                 14.26 ns   (14.05 ns .. 14.50 ns)
std dev              755.1 ps   (615.1 ps .. 1.039 ns)
variance introduced by outliers: 76% (severely inflated)

benchmarking Length/Data.List:10
time                 22.49 ns   (22.14 ns .. 22.82 ns)
                     0.998 R²   (0.996 R² .. 0.999 R²)
mean                 22.18 ns   (21.86 ns .. 22.64 ns)
std dev              1.213 ns   (955.3 ps .. 1.789 ns)
variance introduced by outliers: 76% (severely inflated)

benchmarking Length/Data.DList:10
time                 85.21 ns   (84.00 ns .. 86.25 ns)
                     0.998 R²   (0.997 R² .. 0.999 R²)
mean                 86.18 ns   (85.02 ns .. 87.43 ns)
std dev              4.094 ns   (3.296 ns .. 5.229 ns)
variance introduced by outliers: 69% (severely inflated)

benchmarking Length/Data.Vector:10
time                 9.046 ns   (8.856 ns .. 9.251 ns)
                     0.996 R²   (0.995 R² .. 0.998 R²)
mean                 9.055 ns   (8.908 ns .. 9.211 ns)
std dev              515.2 ps   (439.8 ps .. 624.4 ps)
variance introduced by outliers: 79% (severely inflated)

benchmarking Length/Data.Vector.Unboxed:10
time                 10.47 ns   (10.19 ns .. 10.79 ns)
                     0.996 R²   (0.994 R² .. 0.998 R²)
mean                 10.12 ns   (9.937 ns .. 10.34 ns)
std dev              684.7 ps   (546.7 ps .. 874.9 ps)
variance introduced by outliers: 84% (severely inflated)

benchmarking Length/Data.Vector.Storable:10
time                 8.480 ns   (8.242 ns .. 8.826 ns)
                     0.992 R²   (0.987 R² .. 0.998 R²)
mean                 8.846 ns   (8.604 ns .. 9.214 ns)
std dev              1.002 ns   (693.8 ps .. 1.496 ns)
variance introduced by outliers: 94% (severely inflated)

benchmarking Length/Data.Sequence:10
time                 8.885 ns   (8.691 ns .. 9.118 ns)
                     0.997 R²   (0.994 R² .. 0.999 R²)
mean                 8.745 ns   (8.633 ns .. 8.885 ns)
std dev              438.0 ps   (338.7 ps .. 595.6 ps)
variance introduced by outliers: 74% (severely inflated)

benchmarking Length/Data.Massiv.Array:10
time                 9.519 ns   (9.344 ns .. 9.708 ns)
                     0.998 R²   (0.996 R² .. 0.999 R²)
mean                 9.506 ns   (9.353 ns .. 9.734 ns)
std dev              608.8 ps   (462.5 ps .. 918.8 ps)
variance introduced by outliers: 83% (severely inflated)

benchmarking Length/Data.RRBVector:10
time                 8.835 ns   (8.715 ns .. 8.973 ns)
                     0.999 R²   (0.998 R² .. 0.999 R²)
mean                 8.686 ns   (8.587 ns .. 8.794 ns)
std dev              336.7 ps   (279.6 ps .. 407.0 ps)
variance introduced by outliers: 63% (severely inflated)

benchmarking Length/Data.Acc:10
time                 99.72 ns   (97.45 ns .. 102.0 ns)
                     0.998 R²   (0.997 R² .. 0.999 R²)
mean                 99.08 ns   (98.14 ns .. 100.5 ns)
std dev              3.776 ns   (2.937 ns .. 5.499 ns)
variance introduced by outliers: 58% (severely inflated)

benchmarking Length/Data.List:100
time                 194.1 ns   (192.3 ns .. 196.1 ns)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 194.0 ns   (192.3 ns .. 196.5 ns)
std dev              6.682 ns   (5.333 ns .. 8.795 ns)
variance introduced by outliers: 52% (severely inflated)

benchmarking Length/Data.DList:100
time                 663.6 ns   (648.6 ns .. 677.3 ns)
                     0.998 R²   (0.996 R² .. 0.999 R²)
mean                 651.1 ns   (644.5 ns .. 660.2 ns)
std dev              26.50 ns   (21.69 ns .. 37.29 ns)
variance introduced by outliers: 58% (severely inflated)

benchmarking Length/Data.Vector:100
time                 8.222 ns   (8.041 ns .. 8.504 ns)
                     0.995 R²   (0.994 R² .. 0.997 R²)
mean                 8.474 ns   (8.343 ns .. 8.629 ns)
std dev              485.2 ps   (395.6 ps .. 670.4 ps)
variance introduced by outliers: 79% (severely inflated)

benchmarking Length/Data.Vector.Unboxed:100
time                 10.14 ns   (9.942 ns .. 10.35 ns)
                     0.998 R²   (0.997 R² .. 0.999 R²)
mean                 10.07 ns   (9.918 ns .. 10.26 ns)
std dev              528.7 ps   (431.9 ps .. 687.5 ps)
variance introduced by outliers: 76% (severely inflated)

benchmarking Length/Data.Vector.Storable:100
time                 8.537 ns   (8.341 ns .. 8.751 ns)
                     0.992 R²   (0.986 R² .. 0.997 R²)
mean                 8.576 ns   (8.331 ns .. 8.903 ns)
std dev              980.2 ps   (674.8 ps .. 1.359 ns)
variance introduced by outliers: 94% (severely inflated)

benchmarking Length/Data.Sequence:100
time                 9.172 ns   (8.943 ns .. 9.412 ns)
                     0.997 R²   (0.995 R² .. 0.999 R²)
mean                 9.090 ns   (8.975 ns .. 9.228 ns)
std dev              441.5 ps   (355.6 ps .. 569.5 ps)
variance introduced by outliers: 73% (severely inflated)

benchmarking Length/Data.Massiv.Array:100
time                 9.525 ns   (9.398 ns .. 9.670 ns)
                     0.998 R²   (0.997 R² .. 0.999 R²)
mean                 9.619 ns   (9.469 ns .. 9.848 ns)
std dev              623.8 ps   (464.8 ps .. 834.5 ps)
variance introduced by outliers: 83% (severely inflated)

benchmarking Length/Data.RRBVector:100
time                 8.854 ns   (8.711 ns .. 9.012 ns)
                     0.998 R²   (0.997 R² .. 0.999 R²)
mean                 8.783 ns   (8.654 ns .. 8.909 ns)
std dev              407.2 ps   (338.0 ps .. 512.4 ps)
variance introduced by outliers: 71% (severely inflated)

benchmarking Length/Data.Acc:100
time                 1.220 μs   (1.201 μs .. 1.243 μs)
                     0.998 R²   (0.997 R² .. 0.999 R²)
mean                 1.229 μs   (1.213 μs .. 1.249 μs)
std dev              57.54 ns   (44.51 ns .. 82.94 ns)
variance introduced by outliers: 63% (severely inflated)

benchmarking Length/Data.List:1000
time                 2.167 μs   (2.139 μs .. 2.194 μs)
                     0.999 R²   (0.998 R² .. 1.000 R²)
mean                 2.191 μs   (2.169 μs .. 2.243 μs)
std dev              104.7 ns   (61.30 ns .. 209.9 ns)
variance introduced by outliers: 62% (severely inflated)

benchmarking Length/Data.DList:1000
time                 6.529 μs   (6.418 μs .. 6.634 μs)
                     0.998 R²   (0.998 R² .. 0.999 R²)
mean                 6.551 μs   (6.467 μs .. 6.674 μs)
std dev              348.3 ns   (256.6 ns .. 557.8 ns)
variance introduced by outliers: 65% (severely inflated)

benchmarking Length/Data.Vector:1000
time                 8.643 ns   (8.394 ns .. 8.972 ns)
                     0.992 R²   (0.989 R² .. 0.996 R²)
mean                 8.934 ns   (8.686 ns .. 9.214 ns)
std dev              834.0 ps   (676.6 ps .. 1.032 ns)
variance introduced by outliers: 91% (severely inflated)

benchmarking Length/Data.Vector.Unboxed:1000
time                 10.22 ns   (9.840 ns .. 10.54 ns)
                     0.994 R²   (0.991 R² .. 0.997 R²)
mean                 10.18 ns   (9.973 ns .. 10.41 ns)
std dev              722.5 ps   (600.0 ps .. 901.9 ps)
variance introduced by outliers: 85% (severely inflated)

benchmarking Length/Data.Vector.Storable:1000
time                 8.477 ns   (8.302 ns .. 8.697 ns)
                     0.993 R²   (0.986 R² .. 0.998 R²)
mean                 8.385 ns   (8.165 ns .. 8.792 ns)
std dev              929.3 ps   (507.2 ps .. 1.743 ns)
variance introduced by outliers: 93% (severely inflated)

benchmarking Length/Data.Sequence:1000
time                 9.251 ns   (8.940 ns .. 9.575 ns)
                     0.994 R²   (0.991 R² .. 0.998 R²)
mean                 9.219 ns   (9.011 ns .. 9.515 ns)
std dev              808.8 ps   (626.2 ps .. 1.186 ns)
variance introduced by outliers: 90% (severely inflated)

benchmarking Length/Data.Massiv.Array:1000
time                 9.325 ns   (9.091 ns .. 9.568 ns)
                     0.995 R²   (0.993 R² .. 0.997 R²)
mean                 9.439 ns   (9.264 ns .. 9.633 ns)
std dev              617.5 ps   (515.3 ps .. 766.7 ps)
variance introduced by outliers: 83% (severely inflated)

benchmarking Length/Data.RRBVector:1000
time                 9.076 ns   (8.875 ns .. 9.331 ns)
                     0.995 R²   (0.992 R² .. 0.998 R²)
mean                 9.200 ns   (8.966 ns .. 9.635 ns)
std dev              1.028 ns   (611.1 ps .. 1.710 ns)
variance introduced by outliers: 94% (severely inflated)

benchmarking Length/Data.Acc:1000
time                 12.50 μs   (12.34 μs .. 12.67 μs)
                     0.999 R²   (0.998 R² .. 0.999 R²)
mean                 12.37 μs   (12.23 μs .. 12.50 μs)
std dev              489.4 ns   (423.4 ns .. 647.6 ns)
variance introduced by outliers: 48% (moderately inflated)

benchmarking Length/Data.List:10000
time                 26.29 μs   (25.96 μs .. 26.69 μs)
                     0.999 R²   (0.998 R² .. 0.999 R²)
mean                 26.38 μs   (26.13 μs .. 26.74 μs)
std dev              1.015 μs   (803.2 ns .. 1.379 μs)
variance introduced by outliers: 44% (moderately inflated)

benchmarking Length/Data.DList:10000
time                 69.32 μs   (67.48 μs .. 71.10 μs)
                     0.994 R²   (0.990 R² .. 0.997 R²)
mean                 70.67 μs   (68.85 μs .. 72.75 μs)
std dev              6.701 μs   (5.346 μs .. 8.525 μs)
variance introduced by outliers: 81% (severely inflated)

benchmarking Length/Data.Vector:10000
time                 8.849 ns   (8.667 ns .. 9.033 ns)
                     0.996 R²   (0.994 R² .. 0.997 R²)
mean                 9.031 ns   (8.828 ns .. 9.333 ns)
std dev              787.8 ps   (599.4 ps .. 1.200 ns)
variance introduced by outliers: 90% (severely inflated)

benchmarking Length/Data.Vector.Unboxed:10000
time                 10.44 ns   (10.24 ns .. 10.73 ns)
                     0.992 R²   (0.986 R² .. 0.997 R²)
mean                 11.04 ns   (10.67 ns .. 11.61 ns)
std dev              1.417 ns   (1.073 ns .. 2.255 ns)
variance introduced by outliers: 95% (severely inflated)

benchmarking Length/Data.Vector.Storable:10000
time                 8.458 ns   (8.347 ns .. 8.564 ns)
                     0.998 R²   (0.996 R² .. 0.999 R²)
mean                 8.596 ns   (8.444 ns .. 8.866 ns)
std dev              652.4 ps   (387.2 ps .. 1.116 ns)
variance introduced by outliers: 87% (severely inflated)

benchmarking Length/Data.Sequence:10000
time                 8.433 ns   (8.198 ns .. 8.675 ns)
                     0.995 R²   (0.992 R² .. 0.998 R²)
mean                 8.636 ns   (8.414 ns .. 9.116 ns)
std dev              1.092 ns   (638.1 ps .. 1.906 ns)
variance introduced by outliers: 95% (severely inflated)

benchmarking Length/Data.Massiv.Array:10000
time                 9.722 ns   (9.472 ns .. 10.00 ns)
                     0.996 R²   (0.994 R² .. 0.998 R²)
mean                 9.558 ns   (9.390 ns .. 9.762 ns)
std dev              621.3 ps   (515.6 ps .. 785.6 ps)
variance introduced by outliers: 83% (severely inflated)

benchmarking Length/Data.RRBVector:10000
time                 8.264 ns   (8.152 ns .. 8.441 ns)
                     0.997 R²   (0.995 R² .. 0.999 R²)
mean                 8.530 ns   (8.397 ns .. 8.681 ns)
std dev              465.5 ps   (377.3 ps .. 567.5 ps)
variance introduced by outliers: 78% (severely inflated)

benchmarking Length/Data.Acc:10000
time                 143.4 μs   (139.6 μs .. 147.5 μs)
                     0.996 R²   (0.993 R² .. 0.998 R²)
mean                 148.0 μs   (145.8 μs .. 151.0 μs)
std dev              8.888 μs   (6.346 μs .. 13.07 μs)
variance introduced by outliers: 60% (severely inflated)

benchmarking Stable Sort/Data.List:10
time                 361.6 ns   (350.7 ns .. 377.3 ns)
                     0.991 R²   (0.986 R² .. 0.997 R²)
mean                 367.2 ns   (359.2 ns .. 377.8 ns)
std dev              30.89 ns   (24.47 ns .. 42.38 ns)
variance introduced by outliers: 86% (severely inflated)

benchmarking Stable Sort/Data.Vector:10
time                 207.9 ns   (203.9 ns .. 211.6 ns)
                     0.997 R²   (0.993 R² .. 0.999 R²)
mean                 206.4 ns   (202.6 ns .. 212.4 ns)
std dev              15.95 ns   (9.979 ns .. 29.02 ns)
variance introduced by outliers: 85% (severely inflated)

benchmarking Stable Sort/Data.Vector.Unboxed:10
time                 56.87 ns   (56.12 ns .. 57.82 ns)
                     0.999 R²   (0.998 R² .. 1.000 R²)
mean                 57.08 ns   (56.49 ns .. 57.65 ns)
std dev              2.044 ns   (1.705 ns .. 2.445 ns)
variance introduced by outliers: 56% (severely inflated)

benchmarking Stable Sort/Data.Vector.Storable:10
time                 69.52 ns   (68.69 ns .. 70.53 ns)
                     0.998 R²   (0.997 R² .. 0.999 R²)
mean                 69.93 ns   (69.01 ns .. 71.05 ns)
std dev              3.277 ns   (2.746 ns .. 4.049 ns)
variance introduced by outliers: 69% (severely inflated)

benchmarking Stable Sort/Data.Sequence:10
time                 612.3 ns   (603.3 ns .. 620.9 ns)
                     0.998 R²   (0.998 R² .. 0.999 R²)
mean                 612.7 ns   (606.1 ns .. 621.3 ns)
std dev              24.39 ns   (19.22 ns .. 34.39 ns)
variance introduced by outliers: 56% (severely inflated)

benchmarking Stable Sort/Data.List:100
time                 11.53 μs   (11.30 μs .. 11.85 μs)
                     0.996 R²   (0.994 R² .. 0.997 R²)
mean                 12.12 μs   (11.90 μs .. 12.38 μs)
std dev              808.5 ns   (633.0 ns .. 1.108 μs)
variance introduced by outliers: 73% (severely inflated)

benchmarking Stable Sort/Data.Vector:100
time                 6.695 μs   (6.568 μs .. 6.841 μs)
                     0.998 R²   (0.997 R² .. 0.999 R²)
mean                 6.666 μs   (6.611 μs .. 6.739 μs)
std dev              207.3 ns   (159.8 ns .. 293.5 ns)
variance introduced by outliers: 38% (moderately inflated)

benchmarking Stable Sort/Data.Vector.Unboxed:100
time                 6.040 μs   (5.939 μs .. 6.151 μs)
                     0.997 R²   (0.995 R² .. 0.998 R²)
mean                 6.005 μs   (5.886 μs .. 6.154 μs)
std dev              439.7 ns   (362.5 ns .. 562.6 ns)
variance introduced by outliers: 78% (severely inflated)

benchmarking Stable Sort/Data.Vector.Storable:100
time                 5.103 μs   (4.929 μs .. 5.366 μs)
                     0.991 R²   (0.982 R² .. 0.998 R²)
mean                 5.202 μs   (5.095 μs .. 5.336 μs)
std dev              416.3 ns   (301.4 ns .. 599.9 ns)
variance introduced by outliers: 81% (severely inflated)

benchmarking Stable Sort/Data.Sequence:100
time                 12.75 μs   (12.11 μs .. 13.68 μs)
                     0.965 R²   (0.937 R² .. 0.989 R²)
mean                 14.25 μs   (13.41 μs .. 15.48 μs)
std dev              3.405 μs   (2.566 μs .. 4.457 μs)
variance introduced by outliers: 97% (severely inflated)

benchmarking Stable Sort/Data.List:1000
time                 285.1 μs   (279.4 μs .. 291.8 μs)
                     0.997 R²   (0.996 R² .. 0.998 R²)
mean                 292.9 μs   (288.8 μs .. 301.2 μs)
std dev              18.32 μs   (11.49 μs .. 33.33 μs)
variance introduced by outliers: 58% (severely inflated)

benchmarking Stable Sort/Data.Vector:1000
time                 148.4 μs   (147.4 μs .. 149.7 μs)
                     0.999 R²   (0.998 R² .. 0.999 R²)
mean                 153.3 μs   (150.8 μs .. 156.9 μs)
std dev              9.857 μs   (7.318 μs .. 13.99 μs)
variance introduced by outliers: 63% (severely inflated)

benchmarking Stable Sort/Data.Vector.Unboxed:1000
time                 123.8 μs   (122.2 μs .. 125.6 μs)
                     0.999 R²   (0.998 R² .. 0.999 R²)
mean                 123.2 μs   (122.1 μs .. 124.4 μs)
std dev              3.982 μs   (3.296 μs .. 4.763 μs)
variance introduced by outliers: 31% (moderately inflated)

benchmarking Stable Sort/Data.Vector.Storable:1000
time                 118.7 μs   (117.0 μs .. 120.3 μs)
                     0.992 R²   (0.984 R² .. 0.997 R²)
mean                 130.1 μs   (123.6 μs .. 140.6 μs)
std dev              27.80 μs   (17.95 μs .. 38.40 μs)
variance introduced by outliers: 95% (severely inflated)

benchmarking Stable Sort/Data.Sequence:1000
time                 240.4 μs   (237.4 μs .. 245.0 μs)
                     0.998 R²   (0.997 R² .. 0.999 R²)
mean                 242.7 μs   (240.3 μs .. 246.9 μs)
std dev              10.54 μs   (7.183 μs .. 18.00 μs)
variance introduced by outliers: 41% (moderately inflated)

benchmarking Stable Sort/Data.List:10000
time                 7.413 ms   (7.134 ms .. 7.613 ms)
                     0.994 R²   (0.990 R² .. 0.997 R²)
mean                 7.065 ms   (6.970 ms .. 7.174 ms)
std dev              296.7 μs   (251.2 μs .. 376.1 μs)
variance introduced by outliers: 19% (moderately inflated)

benchmarking Stable Sort/Data.Vector:10000
time                 2.871 ms   (2.748 ms .. 2.969 ms)
                     0.989 R²   (0.983 R² .. 0.994 R²)
mean                 2.901 ms   (2.840 ms .. 3.021 ms)
std dev              269.5 μs   (174.0 μs .. 458.4 μs)
variance introduced by outliers: 63% (severely inflated)

benchmarking Stable Sort/Data.Vector.Unboxed:10000
time                 1.926 ms   (1.877 ms .. 1.983 ms)
                     0.993 R²   (0.988 R² .. 0.996 R²)
mean                 1.952 ms   (1.912 ms .. 1.998 ms)
std dev              138.3 μs   (117.3 μs .. 172.4 μs)
variance introduced by outliers: 52% (severely inflated)

benchmarking Stable Sort/Data.Vector.Storable:10000
time                 1.840 ms   (1.797 ms .. 1.883 ms)
                     0.995 R²   (0.992 R² .. 0.997 R²)
mean                 1.793 ms   (1.766 ms .. 1.829 ms)
std dev              106.6 μs   (80.68 μs .. 150.1 μs)
variance introduced by outliers: 44% (moderately inflated)

benchmarking Stable Sort/Data.Sequence:10000
time                 5.139 ms   (4.971 ms .. 5.286 ms)
                     0.995 R²   (0.993 R² .. 0.998 R²)
mean                 4.992 ms   (4.936 ms .. 5.052 ms)
std dev              174.6 μs   (141.4 μs .. 220.6 μs)
variance introduced by outliers: 16% (moderately inflated)

benchmarking Replicate/Data.List:10
time                 66.76 ns   (66.25 ns .. 67.23 ns)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 66.87 ns   (66.35 ns .. 67.61 ns)
std dev              1.873 ns   (1.391 ns .. 2.685 ns)
variance introduced by outliers: 43% (moderately inflated)

benchmarking Replicate/Data.DList:10
time                 92.06 ns   (88.86 ns .. 95.11 ns)
                     0.994 R²   (0.990 R² .. 0.997 R²)
mean                 92.35 ns   (90.50 ns .. 95.39 ns)
std dev              7.754 ns   (5.306 ns .. 12.50 ns)
variance introduced by outliers: 87% (severely inflated)

benchmarking Replicate/Data.Vector:10
time                 95.83 ns   (94.20 ns .. 97.63 ns)
                     0.998 R²   (0.997 R² .. 0.999 R²)
mean                 94.79 ns   (93.78 ns .. 96.02 ns)
std dev              3.564 ns   (2.770 ns .. 4.561 ns)
variance introduced by outliers: 58% (severely inflated)

benchmarking Replicate/Data.Vector.Unboxed:10
time                 22.56 ns   (22.05 ns .. 23.04 ns)
                     0.995 R²   (0.992 R² .. 0.997 R²)
mean                 21.80 ns   (21.30 ns .. 22.28 ns)
std dev              1.667 ns   (1.380 ns .. 2.074 ns)
variance introduced by outliers: 86% (severely inflated)

benchmarking Replicate/Data.Vector.Storable:10
time                 26.62 ns   (26.08 ns .. 27.34 ns)
                     0.997 R²   (0.995 R² .. 0.999 R²)
mean                 26.95 ns   (26.47 ns .. 27.51 ns)
std dev              1.651 ns   (1.388 ns .. 2.132 ns)
variance introduced by outliers: 80% (severely inflated)

benchmarking Replicate/Data.Sequence:10
time                 83.33 ns   (81.49 ns .. 85.11 ns)
                     0.993 R²   (0.985 R² .. 0.998 R²)
mean                 86.16 ns   (83.00 ns .. 91.89 ns)
std dev              14.16 ns   (5.880 ns .. 22.91 ns)
variance introduced by outliers: 97% (severely inflated)

benchmarking Replicate/Data.RRBVector:10
time                 60.67 ns   (59.75 ns .. 61.71 ns)
                     0.998 R²   (0.997 R² .. 0.999 R²)
mean                 61.54 ns   (60.80 ns .. 62.59 ns)
std dev              2.783 ns   (2.200 ns .. 3.546 ns)
variance introduced by outliers: 67% (severely inflated)

benchmarking Replicate/Data.List:100
time                 688.1 ns   (680.8 ns .. 696.1 ns)
                     0.999 R²   (0.998 R² .. 0.999 R²)
mean                 681.3 ns   (672.7 ns .. 690.7 ns)
std dev              30.25 ns   (25.27 ns .. 36.89 ns)
variance introduced by outliers: 62% (severely inflated)

benchmarking Replicate/Data.DList:100
time                 710.3 ns   (703.9 ns .. 717.7 ns)
                     0.999 R²   (0.998 R² .. 0.999 R²)
mean                 721.9 ns   (713.8 ns .. 733.6 ns)
std dev              33.29 ns   (23.18 ns .. 56.43 ns)
variance introduced by outliers: 63% (severely inflated)

benchmarking Replicate/Data.Vector:100
time                 473.0 ns   (468.0 ns .. 480.9 ns)
                     0.998 R²   (0.997 R² .. 0.999 R²)
mean                 486.2 ns   (478.0 ns .. 495.3 ns)
std dev              28.52 ns   (24.21 ns .. 35.50 ns)
variance introduced by outliers: 75% (severely inflated)

benchmarking Replicate/Data.Vector.Unboxed:100
time                 53.44 ns   (52.32 ns .. 54.61 ns)
                     0.997 R²   (0.995 R² .. 0.999 R²)
mean                 52.01 ns   (51.31 ns .. 52.75 ns)
std dev              2.521 ns   (2.015 ns .. 3.159 ns)
variance introduced by outliers: 70% (severely inflated)

benchmarking Replicate/Data.Vector.Storable:100
time                 61.50 ns   (60.41 ns .. 62.59 ns)
                     0.997 R²   (0.996 R² .. 0.998 R²)
mean                 61.76 ns   (60.76 ns .. 63.01 ns)
std dev              3.844 ns   (3.122 ns .. 4.759 ns)
variance introduced by outliers: 80% (severely inflated)

benchmarking Replicate/Data.Sequence:100
time                 618.5 ns   (601.9 ns .. 643.3 ns)
                     0.991 R²   (0.983 R² .. 0.998 R²)
mean                 623.0 ns   (610.0 ns .. 644.7 ns)
std dev              55.34 ns   (32.70 ns .. 86.84 ns)
variance introduced by outliers: 87% (severely inflated)

benchmarking Replicate/Data.RRBVector:100
time                 421.0 ns   (415.7 ns .. 426.9 ns)
                     0.999 R²   (0.998 R² .. 0.999 R²)
mean                 425.8 ns   (420.9 ns .. 433.5 ns)
std dev              20.16 ns   (13.22 ns .. 34.73 ns)
variance introduced by outliers: 65% (severely inflated)

benchmarking Replicate/Data.List:1000
time                 6.730 μs   (6.640 μs .. 6.851 μs)
                     0.996 R²   (0.991 R² .. 0.999 R²)
mean                 6.853 μs   (6.727 μs .. 7.177 μs)
std dev              630.6 ns   (352.7 ns .. 1.196 μs)
variance introduced by outliers: 85% (severely inflated)

benchmarking Replicate/Data.DList:1000
time                 6.911 μs   (6.792 μs .. 7.072 μs)
                     0.998 R²   (0.996 R² .. 0.999 R²)
mean                 6.938 μs   (6.849 μs .. 7.044 μs)
std dev              341.5 ns   (254.7 ns .. 459.3 ns)
variance introduced by outliers: 61% (severely inflated)

benchmarking Replicate/Data.Vector:1000
time                 3.916 μs   (3.850 μs .. 3.985 μs)
                     0.997 R²   (0.996 R² .. 0.998 R²)
mean                 3.943 μs   (3.874 μs .. 4.025 μs)
std dev              244.8 ns   (197.1 ns .. 309.3 ns)
variance introduced by outliers: 73% (severely inflated)

benchmarking Replicate/Data.Vector.Unboxed:1000
time                 367.8 ns   (361.3 ns .. 376.4 ns)
                     0.996 R²   (0.994 R² .. 0.998 R²)
mean                 371.4 ns   (364.8 ns .. 379.7 ns)
std dev              25.13 ns   (18.24 ns .. 36.58 ns)
variance introduced by outliers: 80% (severely inflated)

benchmarking Replicate/Data.Vector.Storable:1000
time                 397.2 ns   (382.5 ns .. 415.0 ns)
                     0.993 R²   (0.988 R² .. 0.998 R²)
mean                 395.2 ns   (387.8 ns .. 406.3 ns)
std dev              28.92 ns   (19.83 ns .. 42.89 ns)
variance introduced by outliers: 82% (severely inflated)

benchmarking Replicate/Data.Sequence:1000
time                 5.843 μs   (5.681 μs .. 6.045 μs)
                     0.993 R²   (0.990 R² .. 0.997 R²)
mean                 5.915 μs   (5.806 μs .. 6.044 μs)
std dev              390.3 ns   (320.2 ns .. 521.1 ns)
variance introduced by outliers: 74% (severely inflated)

benchmarking Replicate/Data.RRBVector:1000
time                 3.606 μs   (3.570 μs .. 3.651 μs)
                     0.999 R²   (0.998 R² .. 0.999 R²)
mean                 3.687 μs   (3.646 μs .. 3.745 μs)
std dev              160.9 ns   (118.4 ns .. 244.8 ns)
variance introduced by outliers: 57% (severely inflated)

benchmarking Replicate/Data.List:10000
time                 64.42 μs   (62.90 μs .. 66.15 μs)
                     0.996 R²   (0.994 R² .. 0.998 R²)
mean                 63.70 μs   (62.70 μs .. 64.69 μs)
std dev              3.369 μs   (2.820 μs .. 4.051 μs)
variance introduced by outliers: 56% (severely inflated)

benchmarking Replicate/Data.DList:10000
time                 73.29 μs   (69.50 μs .. 78.31 μs)
                     0.970 R²   (0.954 R² .. 0.985 R²)
mean                 73.69 μs   (70.60 μs .. 77.46 μs)
std dev              11.30 μs   (8.871 μs .. 14.12 μs)
variance introduced by outliers: 92% (severely inflated)

benchmarking Replicate/Data.Vector:10000
time                 38.17 μs   (37.00 μs .. 39.80 μs)
                     0.994 R²   (0.990 R² .. 0.998 R²)
mean                 37.57 μs   (36.75 μs .. 38.44 μs)
std dev              2.687 μs   (2.180 μs .. 3.376 μs)
variance introduced by outliers: 73% (severely inflated)

benchmarking Replicate/Data.Vector.Unboxed:10000
time                 3.092 μs   (3.052 μs .. 3.128 μs)
                     0.998 R²   (0.996 R² .. 0.999 R²)
mean                 3.110 μs   (3.051 μs .. 3.240 μs)
std dev              292.4 ns   (154.1 ns .. 524.4 ns)
variance introduced by outliers: 87% (severely inflated)

benchmarking Replicate/Data.Vector.Storable:10000
time                 3.352 μs   (3.320 μs .. 3.390 μs)
                     0.999 R²   (0.998 R² .. 0.999 R²)
mean                 3.405 μs   (3.368 μs .. 3.448 μs)
std dev              146.8 ns   (123.1 ns .. 193.6 ns)
variance introduced by outliers: 56% (severely inflated)

benchmarking Replicate/Data.Sequence:10000
time                 60.35 μs   (58.16 μs .. 62.13 μs)
                     0.993 R²   (0.991 R² .. 0.996 R²)
mean                 59.09 μs   (58.06 μs .. 60.19 μs)
std dev              3.563 μs   (3.017 μs .. 4.331 μs)
variance introduced by outliers: 63% (severely inflated)

benchmarking Replicate/Data.RRBVector:10000
time                 36.55 μs   (35.54 μs .. 37.62 μs)
                     0.992 R²   (0.988 R² .. 0.995 R²)
mean                 37.96 μs   (36.99 μs .. 39.24 μs)
std dev              3.677 μs   (2.921 μs .. 5.460 μs)
variance introduced by outliers: 83% (severely inflated)

benchmarking Min/Data.List:10
time                 24.84 ns   (24.26 ns .. 25.41 ns)
                     0.995 R²   (0.993 R² .. 0.997 R²)
mean                 25.56 ns   (24.76 ns .. 28.59 ns)
std dev              4.323 ns   (1.507 ns .. 9.351 ns)
variance introduced by outliers: 97% (severely inflated)

benchmarking Min/Data.DList:10
time                 171.9 ns   (169.7 ns .. 175.2 ns)
                     0.997 R²   (0.995 R² .. 0.998 R²)
mean                 172.8 ns   (170.0 ns .. 176.3 ns)
std dev              10.53 ns   (8.441 ns .. 13.82 ns)
variance introduced by outliers: 77% (severely inflated)

benchmarking Min/Data.Vector:10
time                 30.43 ns   (30.04 ns .. 30.93 ns)
                     0.999 R²   (0.998 R² .. 1.000 R²)
mean                 30.32 ns   (30.08 ns .. 30.66 ns)
std dev              933.0 ps   (711.1 ps .. 1.334 ns)
variance introduced by outliers: 50% (moderately inflated)

benchmarking Min/Data.Vector.Unboxed:10
time                 15.77 ns   (15.66 ns .. 15.87 ns)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 15.85 ns   (15.75 ns .. 15.99 ns)
std dev              426.6 ps   (310.2 ps .. 662.6 ps)
variance introduced by outliers: 44% (moderately inflated)

benchmarking Min/Data.Vector.Storable:10
time                 17.07 ns   (16.96 ns .. 17.22 ns)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 17.18 ns   (17.02 ns .. 17.36 ns)
std dev              556.0 ps   (444.4 ps .. 712.6 ps)
variance introduced by outliers: 53% (severely inflated)

benchmarking Min/Data.Sequence:10
time                 274.4 ns   (272.1 ns .. 277.6 ns)
                     0.998 R²   (0.996 R² .. 0.999 R²)
mean                 278.5 ns   (274.7 ns .. 285.1 ns)
std dev              15.89 ns   (9.641 ns .. 27.40 ns)
variance introduced by outliers: 74% (severely inflated)

benchmarking Min/Data.Massiv.Array:10
time                 26.96 ns   (26.06 ns .. 27.92 ns)
                     0.994 R²   (0.991 R² .. 0.998 R²)
mean                 27.33 ns   (26.90 ns .. 27.86 ns)
std dev              1.620 ns   (1.392 ns .. 2.089 ns)
variance introduced by outliers: 79% (severely inflated)

benchmarking Min/Data.RRBVector:10
time                 118.7 ns   (115.5 ns .. 122.5 ns)
                     0.995 R²   (0.992 R² .. 0.998 R²)
mean                 115.6 ns   (113.7 ns .. 118.3 ns)
std dev              7.296 ns   (5.827 ns .. 9.667 ns)
variance introduced by outliers: 79% (severely inflated)

benchmarking Min/Data.Acc:10
time                 339.3 ns   (319.1 ns .. 360.3 ns)
                     0.985 R²   (0.977 R² .. 0.998 R²)
mean                 317.8 ns   (311.7 ns .. 330.4 ns)
std dev              28.04 ns   (16.14 ns .. 45.36 ns)
variance introduced by outliers: 87% (severely inflated)

benchmarking Min/Data.List:100
time                 291.8 ns   (286.7 ns .. 298.0 ns)
                     0.997 R²   (0.996 R² .. 0.998 R²)
mean                 291.6 ns   (287.3 ns .. 296.3 ns)
std dev              15.95 ns   (13.22 ns .. 19.12 ns)
variance introduced by outliers: 73% (severely inflated)

benchmarking Min/Data.DList:100
time                 1.604 μs   (1.572 μs .. 1.652 μs)
                     0.996 R²   (0.990 R² .. 1.000 R²)
mean                 1.589 μs   (1.573 μs .. 1.628 μs)
std dev              76.93 ns   (42.69 ns .. 153.3 ns)
variance introduced by outliers: 64% (severely inflated)

benchmarking Min/Data.Vector:100
time                 230.8 ns   (224.5 ns .. 239.6 ns)
                     0.995 R²   (0.990 R² .. 0.999 R²)
mean                 229.4 ns   (226.2 ns .. 235.2 ns)
std dev              14.22 ns   (9.028 ns .. 21.25 ns)
variance introduced by outliers: 78% (severely inflated)

benchmarking Min/Data.Vector.Unboxed:100
time                 83.66 ns   (82.89 ns .. 84.45 ns)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 83.56 ns   (82.95 ns .. 84.38 ns)
std dev              2.380 ns   (1.792 ns .. 3.791 ns)
variance introduced by outliers: 44% (moderately inflated)

benchmarking Min/Data.Vector.Storable:100
time                 100.4 ns   (99.70 ns .. 101.0 ns)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 99.94 ns   (99.35 ns .. 100.8 ns)
std dev              2.302 ns   (1.811 ns .. 3.069 ns)
variance introduced by outliers: 33% (moderately inflated)

benchmarking Min/Data.Sequence:100
time                 3.019 μs   (2.997 μs .. 3.042 μs)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 3.010 μs   (2.990 μs .. 3.037 μs)
std dev              76.92 ns   (60.18 ns .. 102.2 ns)
variance introduced by outliers: 31% (moderately inflated)

benchmarking Min/Data.Massiv.Array:100
time                 84.79 ns   (84.18 ns .. 85.42 ns)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 84.50 ns   (83.94 ns .. 85.20 ns)
std dev              2.061 ns   (1.683 ns .. 2.753 ns)
variance introduced by outliers: 36% (moderately inflated)

benchmarking Min/Data.RRBVector:100
time                 1.175 μs   (1.167 μs .. 1.183 μs)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 1.178 μs   (1.170 μs .. 1.188 μs)
std dev              30.37 ns   (22.92 ns .. 41.05 ns)
variance introduced by outliers: 34% (moderately inflated)

benchmarking Min/Data.Acc:100
time                 3.293 μs   (3.259 μs .. 3.335 μs)
                     0.999 R²   (0.998 R² .. 1.000 R²)
mean                 3.279 μs   (3.256 μs .. 3.312 μs)
std dev              91.12 ns   (64.74 ns .. 134.4 ns)
variance introduced by outliers: 34% (moderately inflated)

benchmarking Min/Data.List:1000
time                 2.613 μs   (2.595 μs .. 2.632 μs)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 2.622 μs   (2.600 μs .. 2.660 μs)
std dev              95.01 ns   (61.07 ns .. 159.9 ns)
variance introduced by outliers: 48% (moderately inflated)

benchmarking Min/Data.DList:1000
time                 15.93 μs   (15.80 μs .. 16.07 μs)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 15.96 μs   (15.86 μs .. 16.11 μs)
std dev              424.2 ns   (327.4 ns .. 628.5 ns)
variance introduced by outliers: 28% (moderately inflated)

benchmarking Min/Data.Vector:1000
time                 2.180 μs   (2.166 μs .. 2.194 μs)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 2.182 μs   (2.168 μs .. 2.199 μs)
std dev              50.10 ns   (41.10 ns .. 68.37 ns)
variance introduced by outliers: 27% (moderately inflated)

benchmarking Min/Data.Vector.Unboxed:1000
time                 813.2 ns   (797.5 ns .. 834.8 ns)
                     0.998 R²   (0.996 R² .. 0.999 R²)
mean                 809.6 ns   (800.2 ns .. 822.4 ns)
std dev              38.18 ns   (27.78 ns .. 55.32 ns)
variance introduced by outliers: 64% (severely inflated)

benchmarking Min/Data.Vector.Storable:1000
time                 965.4 ns   (960.3 ns .. 970.8 ns)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 963.6 ns   (957.9 ns .. 971.4 ns)
std dev              23.25 ns   (16.80 ns .. 38.46 ns)
variance introduced by outliers: 31% (moderately inflated)

benchmarking Min/Data.Sequence:1000
time                 34.15 μs   (33.87 μs .. 34.50 μs)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 34.15 μs   (33.89 μs .. 34.60 μs)
std dev              1.127 μs   (810.9 ns .. 1.694 μs)
variance introduced by outliers: 36% (moderately inflated)

benchmarking Min/Data.Massiv.Array:1000
time                 661.1 ns   (656.9 ns .. 665.3 ns)
                     0.999 R²   (0.998 R² .. 1.000 R²)
mean                 666.5 ns   (659.9 ns .. 679.5 ns)
std dev              30.61 ns   (19.09 ns .. 54.80 ns)
variance introduced by outliers: 63% (severely inflated)

benchmarking Min/Data.RRBVector:1000
time                 11.75 μs   (11.67 μs .. 11.83 μs)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 11.77 μs   (11.69 μs .. 11.90 μs)
std dev              343.1 ns   (256.6 ns .. 480.7 ns)
variance introduced by outliers: 33% (moderately inflated)

benchmarking Min/Data.Acc:1000
time                 40.62 μs   (40.25 μs .. 40.97 μs)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 40.49 μs   (40.23 μs .. 40.84 μs)
std dev              1.068 μs   (757.8 ns .. 1.485 μs)
variance introduced by outliers: 25% (moderately inflated)

benchmarking Min/Data.List:10000
time                 28.03 μs   (27.86 μs .. 28.22 μs)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 28.16 μs   (28.00 μs .. 28.43 μs)
std dev              748.6 ns   (520.5 ns .. 1.222 μs)
variance introduced by outliers: 27% (moderately inflated)

benchmarking Min/Data.DList:10000
time                 229.5 μs   (228.0 μs .. 231.1 μs)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 229.9 μs   (228.4 μs .. 233.8 μs)
std dev              7.517 μs   (4.298 μs .. 13.44 μs)
variance introduced by outliers: 29% (moderately inflated)

benchmarking Min/Data.Vector:10000
time                 21.50 μs   (21.35 μs .. 21.66 μs)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 21.54 μs   (21.40 μs .. 21.74 μs)
std dev              538.0 ns   (383.2 ns .. 773.2 ns)
variance introduced by outliers: 25% (moderately inflated)

benchmarking Min/Data.Vector.Unboxed:10000
time                 7.699 μs   (7.654 μs .. 7.746 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 7.717 μs   (7.671 μs .. 7.782 μs)
std dev              181.0 ns   (129.8 ns .. 285.9 ns)
variance introduced by outliers: 25% (moderately inflated)

benchmarking Min/Data.Vector.Storable:10000
time                 9.264 μs   (9.191 μs .. 9.353 μs)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 9.268 μs   (9.212 μs .. 9.356 μs)
std dev              239.6 ns   (168.8 ns .. 386.8 ns)
variance introduced by outliers: 29% (moderately inflated)

benchmarking Min/Data.Sequence:10000
time                 352.4 μs   (349.4 μs .. 355.4 μs)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 354.6 μs   (352.3 μs .. 359.7 μs)
std dev              10.86 μs   (6.831 μs .. 19.33 μs)
variance introduced by outliers: 24% (moderately inflated)

benchmarking Min/Data.Massiv.Array:10000
time                 6.183 μs   (6.153 μs .. 6.215 μs)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 6.194 μs   (6.160 μs .. 6.232 μs)
std dev              122.4 ns   (98.67 ns .. 153.2 ns)
variance introduced by outliers: 20% (moderately inflated)

benchmarking Min/Data.RRBVector:10000
time                 116.6 μs   (115.9 μs .. 117.4 μs)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 116.9 μs   (116.1 μs .. 118.0 μs)
std dev              2.987 μs   (2.459 μs .. 4.000 μs)
variance introduced by outliers: 22% (moderately inflated)

benchmarking Min/Data.Acc:10000
time                 642.2 μs   (636.5 μs .. 649.6 μs)
                     0.998 R²   (0.997 R² .. 0.999 R²)
mean                 652.5 μs   (646.1 μs .. 662.0 μs)
std dev              27.44 μs   (20.64 μs .. 35.20 μs)
variance introduced by outliers: 34% (moderately inflated)

benchmarking Max/Data.List:10
time                 35.94 ns   (35.67 ns .. 36.29 ns)
                     0.999 R²   (0.998 R² .. 1.000 R²)
mean                 35.90 ns   (35.67 ns .. 36.31 ns)
std dev              1.019 ns   (724.7 ps .. 1.603 ns)
variance introduced by outliers: 45% (moderately inflated)

benchmarking Max/Data.DList:10
time                 171.6 ns   (170.4 ns .. 173.0 ns)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 172.7 ns   (171.5 ns .. 174.3 ns)
std dev              4.558 ns   (3.559 ns .. 6.192 ns)
variance introduced by outliers: 39% (moderately inflated)

benchmarking Max/Data.Vector:10
time                 24.10 ns   (23.90 ns .. 24.30 ns)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 24.09 ns   (23.92 ns .. 24.33 ns)
std dev              668.5 ps   (506.8 ps .. 1.082 ns)
variance introduced by outliers: 45% (moderately inflated)

benchmarking Max/Data.Vector.Unboxed:10
time                 19.63 ns   (19.55 ns .. 19.72 ns)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 19.66 ns   (19.55 ns .. 19.78 ns)
std dev              400.6 ps   (311.0 ps .. 511.6 ps)
variance introduced by outliers: 31% (moderately inflated)

benchmarking Max/Data.Vector.Storable:10
time                 15.51 ns   (15.42 ns .. 15.61 ns)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 15.52 ns   (15.40 ns .. 15.66 ns)
std dev              435.9 ps   (309.4 ps .. 612.4 ps)
variance introduced by outliers: 46% (moderately inflated)

benchmarking Max/Data.Sequence:10
time                 282.9 ns   (280.7 ns .. 285.3 ns)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 284.4 ns   (282.2 ns .. 287.3 ns)
std dev              8.333 ns   (6.012 ns .. 12.92 ns)
variance introduced by outliers: 43% (moderately inflated)

benchmarking Max/Data.Massiv.Array:10
time                 31.52 ns   (31.29 ns .. 31.77 ns)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 31.41 ns   (31.18 ns .. 31.67 ns)
std dev              807.3 ps   (676.2 ps .. 1.014 ns)
variance introduced by outliers: 40% (moderately inflated)

benchmarking Max/Data.RRBVector:10
time                 112.0 ns   (111.5 ns .. 112.7 ns)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 112.0 ns   (111.3 ns .. 112.8 ns)
std dev              2.388 ns   (2.011 ns .. 3.024 ns)
variance introduced by outliers: 30% (moderately inflated)

benchmarking Max/Data.Acc:10
time                 293.5 ns   (291.1 ns .. 296.0 ns)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 292.9 ns   (291.3 ns .. 294.8 ns)
std dev              5.928 ns   (4.892 ns .. 7.559 ns)
variance introduced by outliers: 26% (moderately inflated)

benchmarking Max/Data.List:100
time                 352.5 ns   (338.1 ns .. 368.3 ns)
                     0.991 R²   (0.983 R² .. 0.999 R²)
mean                 345.6 ns   (340.2 ns .. 355.8 ns)
std dev              23.88 ns   (16.33 ns .. 38.02 ns)
variance introduced by outliers: 81% (severely inflated)

benchmarking Max/Data.DList:100
time                 1.565 μs   (1.539 μs .. 1.601 μs)
                     0.997 R²   (0.996 R² .. 0.998 R²)
mean                 1.630 μs   (1.609 μs .. 1.655 μs)
std dev              85.38 ns   (66.68 ns .. 120.2 ns)
variance introduced by outliers: 67% (severely inflated)

benchmarking Max/Data.Vector:100
time                 192.3 ns   (191.2 ns .. 193.6 ns)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 192.8 ns   (191.4 ns .. 195.3 ns)
std dev              5.720 ns   (3.405 ns .. 10.57 ns)
variance introduced by outliers: 44% (moderately inflated)

benchmarking Max/Data.Vector.Unboxed:100
time                 139.6 ns   (138.6 ns .. 140.7 ns)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 139.7 ns   (138.4 ns .. 141.6 ns)
std dev              5.226 ns   (3.898 ns .. 7.283 ns)
variance introduced by outliers: 56% (severely inflated)

benchmarking Max/Data.Vector.Storable:100
time                 73.39 ns   (72.42 ns .. 74.98 ns)
                     0.997 R²   (0.995 R² .. 0.999 R²)
mean                 75.92 ns   (74.78 ns .. 77.46 ns)
std dev              4.415 ns   (3.301 ns .. 5.886 ns)
variance introduced by outliers: 77% (severely inflated)

benchmarking Max/Data.Sequence:100
time                 3.069 μs   (3.054 μs .. 3.084 μs)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 3.070 μs   (3.048 μs .. 3.095 μs)
std dev              79.18 ns   (63.91 ns .. 103.1 ns)
variance introduced by outliers: 31% (moderately inflated)

benchmarking Max/Data.Massiv.Array:100
time                 152.0 ns   (150.4 ns .. 154.1 ns)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 151.8 ns   (150.6 ns .. 153.2 ns)
std dev              4.267 ns   (3.394 ns .. 5.190 ns)
variance introduced by outliers: 42% (moderately inflated)

benchmarking Max/Data.RRBVector:100
time                 1.072 μs   (1.067 μs .. 1.079 μs)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 1.072 μs   (1.066 μs .. 1.080 μs)
std dev              24.06 ns   (19.99 ns .. 29.38 ns)
variance introduced by outliers: 28% (moderately inflated)

benchmarking Max/Data.Acc:100
time                 3.190 μs   (3.170 μs .. 3.213 μs)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 3.187 μs   (3.165 μs .. 3.219 μs)
std dev              84.70 ns   (64.28 ns .. 116.5 ns)
variance introduced by outliers: 32% (moderately inflated)

benchmarking Max/Data.List:1000
time                 3.113 μs   (3.096 μs .. 3.135 μs)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 3.141 μs   (3.108 μs .. 3.189 μs)
std dev              126.7 ns   (94.94 ns .. 192.2 ns)
variance introduced by outliers: 53% (severely inflated)

benchmarking Max/Data.DList:1000
time                 15.52 μs   (15.42 μs .. 15.64 μs)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 15.52 μs   (15.43 μs .. 15.66 μs)
std dev              391.5 ns   (294.9 ns .. 529.6 ns)
variance introduced by outliers: 27% (moderately inflated)

benchmarking Max/Data.Vector:1000
time                 1.834 μs   (1.812 μs .. 1.857 μs)
                     0.999 R²   (0.998 R² .. 1.000 R²)
mean                 1.827 μs   (1.811 μs .. 1.849 μs)
std dev              62.91 ns   (43.61 ns .. 87.81 ns)
variance introduced by outliers: 47% (moderately inflated)

benchmarking Max/Data.Vector.Unboxed:1000
time                 1.275 μs   (1.264 μs .. 1.287 μs)
                     0.999 R²   (0.998 R² .. 1.000 R²)
mean                 1.280 μs   (1.267 μs .. 1.304 μs)
std dev              57.93 ns   (39.92 ns .. 102.7 ns)
variance introduced by outliers: 61% (severely inflated)

benchmarking Max/Data.Vector.Storable:1000
time                 657.5 ns   (652.5 ns .. 662.5 ns)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 658.5 ns   (653.4 ns .. 664.1 ns)
std dev              19.27 ns   (15.62 ns .. 27.56 ns)
variance introduced by outliers: 41% (moderately inflated)

benchmarking Max/Data.Sequence:1000
time                 34.84 μs   (34.63 μs .. 35.04 μs)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 34.76 μs   (34.51 μs .. 35.10 μs)
std dev              927.6 ns   (676.2 ns .. 1.295 μs)
variance introduced by outliers: 27% (moderately inflated)

benchmarking Max/Data.Massiv.Array:1000
time                 1.284 μs   (1.274 μs .. 1.296 μs)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 1.285 μs   (1.277 μs .. 1.298 μs)
std dev              33.75 ns   (25.15 ns .. 47.76 ns)
variance introduced by outliers: 34% (moderately inflated)

benchmarking Max/Data.RRBVector:1000
time                 10.79 μs   (10.72 μs .. 10.87 μs)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 10.83 μs   (10.75 μs .. 10.91 μs)
std dev              283.0 ns   (224.4 ns .. 382.2 ns)
variance introduced by outliers: 29% (moderately inflated)

benchmarking Max/Data.Acc:1000
time                 39.57 μs   (39.22 μs .. 39.89 μs)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 39.63 μs   (39.36 μs .. 39.98 μs)
std dev              1.034 μs   (793.4 ns .. 1.480 μs)
variance introduced by outliers: 25% (moderately inflated)

benchmarking Max/Data.List:10000
time                 30.74 μs   (30.51 μs .. 30.97 μs)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 30.79 μs   (30.55 μs .. 31.10 μs)
std dev              933.4 ns   (667.5 ns .. 1.415 μs)
variance introduced by outliers: 32% (moderately inflated)

benchmarking Max/Data.DList:10000
time                 226.7 μs   (224.8 μs .. 229.1 μs)
                     0.998 R²   (0.995 R² .. 1.000 R²)
mean                 229.1 μs   (226.8 μs .. 233.5 μs)
std dev              10.09 μs   (6.521 μs .. 16.71 μs)
variance introduced by outliers: 42% (moderately inflated)

benchmarking Max/Data.Vector:10000
time                 18.13 μs   (17.93 μs .. 18.33 μs)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 18.09 μs   (17.96 μs .. 18.24 μs)
std dev              492.5 ns   (407.5 ns .. 593.4 ns)
variance introduced by outliers: 29% (moderately inflated)

benchmarking Max/Data.Vector.Unboxed:10000
time                 12.31 μs   (12.22 μs .. 12.43 μs)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 12.33 μs   (12.24 μs .. 12.47 μs)
std dev              401.4 ns   (287.0 ns .. 543.5 ns)
variance introduced by outliers: 39% (moderately inflated)

benchmarking Max/Data.Vector.Storable:10000
time                 6.230 μs   (6.187 μs .. 6.274 μs)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 6.216 μs   (6.176 μs .. 6.259 μs)
std dev              141.1 ns   (113.7 ns .. 187.2 ns)
variance introduced by outliers: 25% (moderately inflated)

benchmarking Max/Data.Sequence:10000
time                 356.8 μs   (353.4 μs .. 360.4 μs)
                     0.998 R²   (0.995 R² .. 1.000 R²)
mean                 357.3 μs   (353.9 μs .. 364.1 μs)
std dev              15.61 μs   (9.578 μs .. 26.39 μs)
variance introduced by outliers: 39% (moderately inflated)

benchmarking Max/Data.Massiv.Array:10000
time                 12.43 μs   (12.32 μs .. 12.58 μs)
                     0.999 R²   (0.998 R² .. 1.000 R²)
mean                 12.43 μs   (12.32 μs .. 12.56 μs)
std dev              409.6 ns   (320.5 ns .. 513.4 ns)
variance introduced by outliers: 39% (moderately inflated)

benchmarking Max/Data.RRBVector:10000
time                 107.0 μs   (106.1 μs .. 108.1 μs)
                     0.999 R²   (0.998 R² .. 0.999 R²)
mean                 107.3 μs   (106.5 μs .. 108.4 μs)
std dev              2.916 μs   (2.328 μs .. 3.881 μs)
variance introduced by outliers: 24% (moderately inflated)

benchmarking Max/Data.Acc:10000
time                 635.3 μs   (630.7 μs .. 640.4 μs)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 635.3 μs   (630.3 μs .. 640.8 μs)
std dev              18.16 μs   (14.46 μs .. 25.27 μs)
variance introduced by outliers: 19% (moderately inflated)

benchmarking Filter Element/Data.List:1
time                 123.7 μs   (123.0 μs .. 124.6 μs)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 124.5 μs   (123.4 μs .. 126.0 μs)
std dev              4.399 μs   (3.042 μs .. 6.454 μs)
variance introduced by outliers: 34% (moderately inflated)

benchmarking Filter Element/Data.Vector:1
time                 111.2 μs   (110.3 μs .. 112.1 μs)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 111.1 μs   (110.3 μs .. 112.4 μs)
std dev              3.406 μs   (2.324 μs .. 5.921 μs)
variance introduced by outliers: 28% (moderately inflated)

benchmarking Filter Element/Data.Vector.Unboxed:1
time                 78.15 μs   (77.50 μs .. 78.82 μs)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 78.49 μs   (77.92 μs .. 79.34 μs)
std dev              2.406 μs   (1.716 μs .. 4.040 μs)
variance introduced by outliers: 30% (moderately inflated)

benchmarking Filter Element/Data.Vector.Storable:1
time                 105.1 μs   (104.1 μs .. 106.2 μs)
                     0.999 R²   (0.999 R² .. 0.999 R²)
mean                 104.9 μs   (104.1 μs .. 106.0 μs)
std dev              3.297 μs   (2.656 μs .. 3.967 μs)
variance introduced by outliers: 30% (moderately inflated)

benchmarking Filter Element/Data.Sequence:1
time                 286.2 μs   (283.2 μs .. 289.1 μs)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 288.0 μs   (285.5 μs .. 291.0 μs)
std dev              9.264 μs   (6.498 μs .. 12.86 μs)
variance introduced by outliers: 26% (moderately inflated)

benchmarking Filter Element/Data.List:100
time                 123.6 μs   (122.6 μs .. 124.7 μs)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 124.1 μs   (122.9 μs .. 125.6 μs)
std dev              4.359 μs   (3.177 μs .. 6.400 μs)
variance introduced by outliers: 34% (moderately inflated)

benchmarking Filter Element/Data.Vector:100
time                 110.4 μs   (109.5 μs .. 111.4 μs)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 110.6 μs   (109.9 μs .. 111.5 μs)
std dev              2.696 μs   (2.063 μs .. 4.467 μs)
variance introduced by outliers: 20% (moderately inflated)

benchmarking Filter Element/Data.Vector.Unboxed:100
time                 78.11 μs   (77.44 μs .. 78.86 μs)
                     0.999 R²   (0.999 R² .. 0.999 R²)
mean                 78.38 μs   (77.66 μs .. 79.44 μs)
std dev              2.952 μs   (2.042 μs .. 4.693 μs)
variance introduced by outliers: 39% (moderately inflated)

benchmarking Filter Element/Data.Vector.Storable:100
time                 106.9 μs   (105.8 μs .. 108.5 μs)
                     0.998 R²   (0.997 R² .. 1.000 R²)
mean                 106.7 μs   (105.6 μs .. 108.8 μs)
std dev              4.462 μs   (2.708 μs .. 8.028 μs)
variance introduced by outliers: 43% (moderately inflated)

benchmarking Filter Element/Data.Sequence:100
time                 288.8 μs   (286.0 μs .. 291.1 μs)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 288.6 μs   (286.4 μs .. 291.6 μs)
std dev              8.371 μs   (5.957 μs .. 12.03 μs)
variance introduced by outliers: 23% (moderately inflated)

benchmarking Filter Element/Data.List:1000
time                 123.7 μs   (122.8 μs .. 124.6 μs)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 123.9 μs   (123.1 μs .. 125.1 μs)
std dev              3.366 μs   (2.567 μs .. 4.492 μs)
variance introduced by outliers: 24% (moderately inflated)

benchmarking Filter Element/Data.Vector:1000
time                 112.0 μs   (110.9 μs .. 113.2 μs)
                     0.999 R²   (0.999 R² .. 0.999 R²)
mean                 111.5 μs   (110.3 μs .. 113.0 μs)
std dev              4.467 μs   (3.161 μs .. 6.955 μs)
variance introduced by outliers: 40% (moderately inflated)

benchmarking Filter Element/Data.Vector.Unboxed:1000
time                 78.22 μs   (77.50 μs .. 78.95 μs)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 78.18 μs   (77.61 μs .. 79.41 μs)
std dev              2.676 μs   (1.691 μs .. 4.438 μs)
variance introduced by outliers: 35% (moderately inflated)

benchmarking Filter Element/Data.Vector.Storable:1000
time                 106.5 μs   (105.6 μs .. 107.4 μs)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 107.0 μs   (106.1 μs .. 108.6 μs)
std dev              3.786 μs   (2.547 μs .. 6.396 μs)
variance introduced by outliers: 35% (moderately inflated)

benchmarking Filter Element/Data.Sequence:1000
time                 287.9 μs   (285.5 μs .. 290.6 μs)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 289.3 μs   (287.3 μs .. 292.1 μs)
std dev              8.322 μs   (6.385 μs .. 12.30 μs)
variance introduced by outliers: 22% (moderately inflated)

benchmarking Filter Element/Data.List:10000
time                 125.1 μs   (123.2 μs .. 127.3 μs)
                     0.998 R²   (0.998 R² .. 0.999 R²)
mean                 124.6 μs   (123.7 μs .. 126.3 μs)
std dev              3.993 μs   (2.945 μs .. 5.596 μs)
variance introduced by outliers: 30% (moderately inflated)

benchmarking Filter Element/Data.Vector:10000
time                 110.9 μs   (110.0 μs .. 111.9 μs)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 110.9 μs   (110.0 μs .. 112.0 μs)
std dev              3.401 μs   (2.516 μs .. 4.754 μs)
variance introduced by outliers: 28% (moderately inflated)

benchmarking Filter Element/Data.Vector.Unboxed:10000
time                 77.95 μs   (77.28 μs .. 78.59 μs)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 78.16 μs   (77.45 μs .. 79.15 μs)
std dev              2.731 μs   (2.012 μs .. 3.843 μs)
variance introduced by outliers: 35% (moderately inflated)

benchmarking Filter Element/Data.Vector.Storable:10000
time                 108.1 μs   (107.3 μs .. 109.1 μs)
                     0.999 R²   (0.998 R² .. 1.000 R²)
mean                 108.7 μs   (107.8 μs .. 110.4 μs)
std dev              3.809 μs   (2.253 μs .. 5.843 μs)
variance introduced by outliers: 34% (moderately inflated)

benchmarking Filter Element/Data.Sequence:10000
time                 317.5 μs   (314.5 μs .. 321.4 μs)
                     0.999 R²   (0.997 R² .. 1.000 R²)
mean                 315.6 μs   (312.5 μs .. 319.3 μs)
std dev              11.16 μs   (8.316 μs .. 14.75 μs)
variance introduced by outliers: 31% (moderately inflated)

benchmarking Filter By Index/Data.Vector:1
time                 178.0 μs   (176.0 μs .. 180.3 μs)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 178.5 μs   (177.2 μs .. 180.3 μs)
std dev              5.109 μs   (3.858 μs .. 7.272 μs)
variance introduced by outliers: 24% (moderately inflated)

benchmarking Filter By Index/Data.Vector.Unboxed:1
time                 77.58 μs   (76.92 μs .. 78.27 μs)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 77.51 μs   (76.95 μs .. 78.17 μs)
std dev              2.055 μs   (1.651 μs .. 2.774 μs)
variance introduced by outliers: 24% (moderately inflated)

benchmarking Filter By Index/Data.Vector.Storable:1
time                 108.4 μs   (107.4 μs .. 109.5 μs)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 108.2 μs   (107.4 μs .. 109.1 μs)
std dev              2.917 μs   (2.152 μs .. 3.685 μs)
variance introduced by outliers: 23% (moderately inflated)

benchmarking Filter By Index/Data.Vector:100
time                 178.7 μs   (177.1 μs .. 180.4 μs)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 179.4 μs   (178.1 μs .. 181.0 μs)
std dev              4.661 μs   (3.792 μs .. 5.755 μs)
variance introduced by outliers: 21% (moderately inflated)

benchmarking Filter By Index/Data.Vector.Unboxed:100
time                 77.25 μs   (76.61 μs .. 77.88 μs)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 77.37 μs   (76.76 μs .. 78.39 μs)
std dev              2.591 μs   (1.767 μs .. 3.995 μs)
variance introduced by outliers: 34% (moderately inflated)

benchmarking Filter By Index/Data.Vector.Storable:100
time                 107.8 μs   (106.8 μs .. 108.8 μs)
                     0.999 R²   (0.998 R² .. 1.000 R²)
mean                 107.9 μs   (107.1 μs .. 109.1 μs)
std dev              3.304 μs   (2.102 μs .. 4.816 μs)
variance introduced by outliers: 28% (moderately inflated)

benchmarking Filter By Index/Data.Vector:1000
time                 178.1 μs   (176.8 μs .. 179.5 μs)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 178.0 μs   (176.8 μs .. 179.5 μs)
std dev              4.343 μs   (3.364 μs .. 6.301 μs)
variance introduced by outliers: 19% (moderately inflated)

benchmarking Filter By Index/Data.Vector.Unboxed:1000
time                 77.48 μs   (76.48 μs .. 78.38 μs)
                     0.999 R²   (0.998 R² .. 0.999 R²)
mean                 77.10 μs   (76.47 μs .. 78.04 μs)
std dev              2.556 μs   (1.912 μs .. 3.941 μs)
variance introduced by outliers: 33% (moderately inflated)

benchmarking Filter By Index/Data.Vector.Storable:1000
time                 107.7 μs   (106.7 μs .. 108.7 μs)
                     0.999 R²   (0.998 R² .. 1.000 R²)
mean                 107.9 μs   (107.1 μs .. 108.9 μs)
std dev              2.975 μs   (2.224 μs .. 4.108 μs)
variance introduced by outliers: 24% (moderately inflated)

benchmarking Filter By Index/Data.Vector:10000
time                 178.8 μs   (176.7 μs .. 180.9 μs)
                     0.999 R²   (0.998 R² .. 0.999 R²)
mean                 178.7 μs   (177.1 μs .. 180.8 μs)
std dev              6.410 μs   (4.599 μs .. 9.077 μs)
variance introduced by outliers: 33% (moderately inflated)

benchmarking Filter By Index/Data.Vector.Unboxed:10000
time                 77.39 μs   (76.65 μs .. 78.37 μs)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 77.59 μs   (77.01 μs .. 78.43 μs)
std dev              2.381 μs   (1.816 μs .. 3.421 μs)
variance introduced by outliers: 30% (moderately inflated)

benchmarking Filter By Index/Data.Vector.Storable:10000
time                 107.2 μs   (105.9 μs .. 108.6 μs)
                     0.999 R²   (0.998 R² .. 1.000 R²)
mean                 107.1 μs   (106.3 μs .. 108.6 μs)
std dev              3.700 μs   (2.416 μs .. 6.152 μs)
variance introduced by outliers: 34% (moderately inflated)

Benchmark time: FINISH
```

---

</details>

Results :point_up_2:

My laptop still can be considered pretty powerful, if needed - I can load into a clean environment & send clean benchmark update.