### PR TITLE
Switch to tasty-bench and output relative comparisons

### DIFF
--- a/Report.hs
+++ b/Report.hs
@@ -35,13 +35,13 @@ reportFromCsv fp = do
               (filter
                  (not . all (all null))
                  (groupBy
-                    (on (==) (takeWhile (/= '/') . concat . take 1))
+                    (on (==) (takeWhile (/= '.') . stripAll . concat . take 1))
                     rows))))
     _ -> error "Couldn't parse csv"
 
 format :: [[String]] -> String
 format rows =
-  ("## " ++ takeWhile (/= '/') (concat (concat (take 1 (drop 1 rows))))) ++
+  ("## " ++ takeWhile (/= '.') (stripAll (concat (concat (take 1 (drop 1 rows)))))) ++
   "\n\n" ++
   unlines
     [ "|Name|" ++ intercalate "|" scales ++ "|"
@@ -73,15 +73,20 @@ format rows =
       let s =
             takeWhile
               (/= ':')
-              (dropWhile (== '/') (dropWhile (/= '/') (concat (take 1 row))))
+              (dropWhile (== '.') (dropWhile (/= '.') (stripAll (concat (take 1 row)))))
       in s
     rowScale row =
       let scale = dropWhile (== ':') (dropWhile (/= ':') (concat (take 1 row)))
       in scale
 
+-- | Strip "All." prefix.
+stripAll :: String -> String
+stripAll = drop 4
+
+-- | Inputs are in picoseconds, so scaling by 1e-12.
 float :: [Double] -> Double -> String
-float others x = let (scale, ext) = secs (mean others)
-                 in with (x * scale) ext
+float others x = let (scale, ext) = secs (mean others * 1e-12)
+                 in with (x * 1e-12 * scale) ext
 
 -- | Convert a number of seconds to a string.  The string will consist
 -- of four decimal places, followed by a short description of the time

--- a/bench.cabal
+++ b/bench.cabal
@@ -15,7 +15,8 @@ benchmark time
   build-depends:     base
                    , directory
                    , vector
-                   , criterion
+                   , tasty
+                   , tasty-bench
                    , deepseq
                    , containers
                    , vector-algorithms

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,3 +2,4 @@ resolver: lts-18.5
 extra-deps:
 - rrb-vector-0.1.1.0
 - acc-0.1.3@sha256:8c63dda349e4b37bb8de1977bc35db05d77c34fa85becb09dcb7e29bc00d52f9,3806
+- tasty-bench-0.3.1


### PR DESCRIPTION
As suggested in #17, this switches from `criterion` to `tasty-bench`. The main tangible benefit is that relative comparisons are immediately visible in command line:

```
  Stable Sort
    Data.List:10:               OK (0.67s)
      576  ns ± 129 ns, 2.46x
    Data.Vector:10:             OK (0.52s)
      234  ns ±  57 ns
    Data.Vector.Unboxed:10:     OK (0.68s)
      76.9 ns ±  15 ns, 0.33x
    Data.Vector.Storable:10:    OK (0.66s)
      70.3 ns ±  17 ns, 0.30x
    Data.Sequence:10:           OK (0.83s)
      718  ns ± 149 ns, 3.07x
```